### PR TITLE
Feature/SDK-613 minor code cleanup

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/MagicLinksImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/MagicLinksImpl.kt
@@ -2,11 +2,13 @@ package com.stytch.sdk
 
 import com.stytch.sdk.network.StytchApi
 import com.stytch.sessions.launchSessionUpdater
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-internal class MagicLinksImpl internal constructor() : MagicLinks {
+internal class MagicLinksImpl internal constructor(
+    private val externalScope: CoroutineScope
+) : MagicLinks {
 
     override val email: MagicLinks.EmailMagicLinks = EmailMagicLinksImpl()
 
@@ -39,9 +41,9 @@ internal class MagicLinksImpl internal constructor() : MagicLinks {
         parameters: MagicLinks.AuthParameters,
         callback: (response: AuthResponse) -> Unit,
     ) {
-        GlobalScope.launch(StytchClient.uiDispatcher) {
+        externalScope.launch(StytchClient.uiDispatcher) {
             val result = authenticate(parameters)
-//              change to main thread to call callback
+            // change to main thread to call callback
             callback(result)
         }
     }
@@ -82,10 +84,10 @@ internal class MagicLinksImpl internal constructor() : MagicLinks {
             parameters: MagicLinks.EmailMagicLinks.Parameters,
             callback: (response: LoginOrCreateUserByEmailResponse) -> Unit,
         ) {
-//          call endpoint in IO thread
-            GlobalScope.launch(StytchClient.uiDispatcher) {
+            // call endpoint in IO thread
+            externalScope.launch(StytchClient.uiDispatcher) {
                 val result = loginOrCreate(parameters)
-//              change to main thread to call callback
+                // change to main thread to call callback
                 callback(result)
             }
         }

--- a/sdk/src/main/java/com/stytch/sdk/OTPImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/OTPImpl.kt
@@ -2,11 +2,13 @@ package com.stytch.sdk
 
 import com.stytch.sdk.network.StytchApi
 import com.stytch.sessions.launchSessionUpdater
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-internal class OTPImpl internal constructor() : OTP {
+internal class OTPImpl internal constructor(
+    private val externalScope: CoroutineScope
+) : OTP {
 
     override val sms: OTP.SmsOTP = SmsOTPImpl()
     override val whatsapp: OTP.WhatsAppOTP = WhatsAppOTPImpl()
@@ -31,7 +33,7 @@ internal class OTPImpl internal constructor() : OTP {
         parameters: OTP.AuthParameters,
         callback: (response: AuthResponse) -> Unit
     ) {
-        GlobalScope.launch(StytchClient.uiDispatcher) {
+        externalScope.launch(StytchClient.uiDispatcher) {
             val result = authenticate(parameters)
             callback(result)
         }
@@ -54,7 +56,7 @@ internal class OTPImpl internal constructor() : OTP {
             parameters: OTP.SmsOTP.Parameters,
             callback: (response: LoginOrCreateOTPResponse) -> Unit
         ) {
-            GlobalScope.launch(StytchClient.uiDispatcher) {
+            externalScope.launch(StytchClient.uiDispatcher) {
                 val result = loginOrCreate(parameters)
                 callback(result)
             }
@@ -78,7 +80,7 @@ internal class OTPImpl internal constructor() : OTP {
             parameters: OTP.WhatsAppOTP.Parameters,
             callback: (response: LoginOrCreateOTPResponse) -> Unit
         ) {
-            GlobalScope.launch(StytchClient.uiDispatcher) {
+            externalScope.launch(StytchClient.uiDispatcher) {
                 val result = loginOrCreate(parameters)
                 callback(result)
             }
@@ -102,7 +104,7 @@ internal class OTPImpl internal constructor() : OTP {
             parameters: OTP.EmailOTP.Parameters,
             callback: (response: LoginOrCreateOTPResponse) -> Unit
         ) {
-            GlobalScope.launch(StytchClient.uiDispatcher) {
+            externalScope.launch(StytchClient.uiDispatcher) {
                 val result = loginOrCreate(parameters)
                 callback(result)
             }

--- a/sdk/src/main/java/com/stytch/sdk/PasswordsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/PasswordsImpl.kt
@@ -2,16 +2,17 @@ package com.stytch.sdk
 
 import com.stytch.sdk.network.StytchApi
 import com.stytch.sessions.launchSessionUpdater
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-internal class PasswordsImpl internal constructor() : Passwords {
+internal class PasswordsImpl internal constructor(
+    private val externalScope: CoroutineScope
+) : Passwords {
 
     override suspend fun authenticate(parameters: Passwords.AuthParameters): AuthResponse {
         val result: AuthResponse
         withContext(StytchClient.ioDispatcher) {
-
             result = StytchApi.Passwords.authenticate(
                 email = parameters.email,
                 password = parameters.password,
@@ -27,7 +28,7 @@ internal class PasswordsImpl internal constructor() : Passwords {
         parameters: Passwords.AuthParameters,
         callback: (response: AuthResponse) -> Unit
     ) {
-        GlobalScope.launch(StytchClient.uiDispatcher) {
+        externalScope.launch(StytchClient.uiDispatcher) {
             val result = authenticate(parameters)
             callback(result)
         }
@@ -53,7 +54,7 @@ internal class PasswordsImpl internal constructor() : Passwords {
         parameters: Passwords.CreateParameters,
         callback: (response: PasswordsCreateResponse) -> Unit
     ) {
-        GlobalScope.launch(StytchClient.uiDispatcher) {
+        externalScope.launch(StytchClient.uiDispatcher) {
             val result = create(parameters)
             callback(result)
         }
@@ -93,7 +94,7 @@ internal class PasswordsImpl internal constructor() : Passwords {
         parameters: Passwords.ResetByEmailStartParameters,
         callback: (response: BaseResponse) -> Unit
     ) {
-        GlobalScope.launch(StytchClient.uiDispatcher) {
+        externalScope.launch(StytchClient.uiDispatcher) {
             val result = resetByEmailStart(parameters)
             callback(result)
         }
@@ -130,7 +131,7 @@ internal class PasswordsImpl internal constructor() : Passwords {
         parameters: Passwords.ResetByEmailParameters,
         callback: (response: AuthResponse) -> Unit
     ) {
-        GlobalScope.launch(StytchClient.uiDispatcher) {
+        externalScope.launch(StytchClient.uiDispatcher) {
             val result = resetByEmail(parameters)
             callback(result)
         }
@@ -151,7 +152,7 @@ internal class PasswordsImpl internal constructor() : Passwords {
         parameters: Passwords.StrengthCheckParameters,
         callback: (response: PasswordsStrengthCheckResponse) -> Unit
     ) {
-        GlobalScope.launch(StytchClient.uiDispatcher) {
+        externalScope.launch(StytchClient.uiDispatcher) {
             val result = strengthCheck(parameters)
             callback(result)
         }

--- a/sdk/src/main/java/com/stytch/sdk/SessionsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/SessionsImpl.kt
@@ -1,13 +1,7 @@
-package com.stytch.sessions
+package com.stytch.sdk
 
-import com.stytch.sdk.AuthResponse
-import com.stytch.sdk.BaseResponse
-import com.stytch.sdk.LoginOrCreateUserByEmailResponse
-import com.stytch.sdk.Sessions
-import com.stytch.sdk.StytchClient
-import com.stytch.sdk.StytchExceptions
-import com.stytch.sdk.StytchResult
 import com.stytch.sdk.network.StytchApi
+import com.stytch.sessions.launchSessionUpdater
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -34,9 +28,7 @@ internal class SessionsImpl internal constructor() : Sessions {
     override suspend fun authenticate(authParams: Sessions.AuthParams): AuthResponse {
         val result: AuthResponse
         withContext(StytchClient.ioDispatcher) {
-
             // do not revoke session here since we using stored data to authenticate
-
             // call backend endpoint
             result = StytchApi.Sessions.authenticate(
                 authParams.sessionDurationMinutes?.toInt()
@@ -48,10 +40,10 @@ internal class SessionsImpl internal constructor() : Sessions {
     }
 
     override fun authenticate(authParams: Sessions.AuthParams, callback: (AuthResponse) -> Unit) {
-//          call endpoint in IO thread
+        // call endpoint in IO thread
         GlobalScope.launch(StytchClient.uiDispatcher) {
             val result = authenticate(authParams)
-//          change to main thread to call callback
+            // change to main thread to call callback
             callback(result)
         }
     }
@@ -61,7 +53,7 @@ internal class SessionsImpl internal constructor() : Sessions {
         withContext(StytchClient.ioDispatcher) {
             result = StytchApi.Sessions.revoke()
         }
-//            remove stored session
+        // remove stored session
         try {
             StytchClient.sessionStorage.revoke()
         } catch (ex: Exception) {
@@ -71,10 +63,10 @@ internal class SessionsImpl internal constructor() : Sessions {
     }
 
     override fun revoke(callback: (BaseResponse) -> Unit) {
-//          call endpoint in IO thread
+        // call endpoint in IO thread
         GlobalScope.launch(StytchClient.uiDispatcher) {
             val result = revoke()
-//          change to main thread to call callback
+            // change to main thread to call callback
             callback(result)
         }
     }

--- a/sdk/src/main/java/com/stytch/sdk/SessionsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/SessionsImpl.kt
@@ -2,11 +2,13 @@ package com.stytch.sdk
 
 import com.stytch.sdk.network.StytchApi
 import com.stytch.sessions.launchSessionUpdater
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-internal class SessionsImpl internal constructor() : Sessions {
+internal class SessionsImpl internal constructor(
+    private val externalScope: CoroutineScope
+) : Sessions {
     override val sessionToken: String?
         get() {
             try {
@@ -41,7 +43,7 @@ internal class SessionsImpl internal constructor() : Sessions {
 
     override fun authenticate(authParams: Sessions.AuthParams, callback: (AuthResponse) -> Unit) {
         // call endpoint in IO thread
-        GlobalScope.launch(StytchClient.uiDispatcher) {
+        externalScope.launch(StytchClient.uiDispatcher) {
             val result = authenticate(authParams)
             // change to main thread to call callback
             callback(result)
@@ -64,7 +66,7 @@ internal class SessionsImpl internal constructor() : Sessions {
 
     override fun revoke(callback: (BaseResponse) -> Unit) {
         // call endpoint in IO thread
-        GlobalScope.launch(StytchClient.uiDispatcher) {
+        externalScope.launch(StytchClient.uiDispatcher) {
             val result = revoke()
             // change to main thread to call callback
             callback(result)

--- a/sdk/src/main/java/com/stytch/sdk/StytchClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/StytchClient.kt
@@ -12,6 +12,7 @@ import com.stytch.sdk.network.responseData.LoginOrCreateOTPData
 import com.stytch.sdk.network.responseData.StrengthCheckResponse
 import com.stytch.sessions.SessionStorage
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -61,6 +62,8 @@ public object StytchClient {
 
     internal val sessionStorage = SessionStorage()
 
+    internal val externalScope: CoroutineScope = GlobalScope // TODO: SDK-614
+
     /**
      * Configures the StytchClient, setting the publicToken and hostUrl.
      * @param publicToken Available via the Stytch dashboard in the API keys section
@@ -88,7 +91,7 @@ public object StytchClient {
     /**
      * Exposes an instance of email magic links
      */
-    public val magicLinks: MagicLinks = MagicLinksImpl()
+    public val magicLinks: MagicLinks = MagicLinksImpl(externalScope)
         get() {
             assertInitialized()
             return field
@@ -97,7 +100,7 @@ public object StytchClient {
     /**
      * Exposes an instance of otp
      */
-    public val otps: OTP = OTPImpl()
+    public val otps: OTP = OTPImpl(externalScope)
         get() {
             assertInitialized()
             return field
@@ -106,7 +109,7 @@ public object StytchClient {
     /**
      * Exposes an instance of passwords
      */
-    public val passwords: Passwords = PasswordsImpl()
+    public val passwords: Passwords = PasswordsImpl(externalScope)
         get() {
             assertInitialized()
             return field
@@ -115,7 +118,7 @@ public object StytchClient {
     /**
      * Exposes an instance of sessions
      */
-    public val sessions: Sessions = SessionsImpl()
+    public val sessions: Sessions = SessionsImpl(externalScope)
         get() {
             assertInitialized()
             return field
@@ -205,7 +208,7 @@ public object StytchClient {
         sessionDurationMinutes: UInt,
         callback: (response: AuthResponse) -> Unit
     ) {
-        GlobalScope.launch(uiDispatcher) {
+        externalScope.launch(uiDispatcher) {
             val result = handle(uri, sessionDurationMinutes)
             // change to main thread to call callback
             callback(result)

--- a/sdk/src/main/java/com/stytch/sdk/StytchClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/StytchClient.kt
@@ -11,7 +11,6 @@ import com.stytch.sdk.network.responseData.CreateResponse
 import com.stytch.sdk.network.responseData.LoginOrCreateOTPData
 import com.stytch.sdk.network.responseData.StrengthCheckResponse
 import com.stytch.sessions.SessionStorage
-import com.stytch.sessions.SessionsImpl
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope

--- a/sdk/src/main/java/com/stytch/sdk/StytchClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/StytchClient.kt
@@ -88,8 +88,7 @@ public object StytchClient {
     /**
      * Exposes an instance of email magic links
      */
-    public var magicLinks: MagicLinks = MagicLinksImpl()
-        private set
+    public val magicLinks: MagicLinks = MagicLinksImpl()
         get() {
             assertInitialized()
             return field
@@ -98,8 +97,7 @@ public object StytchClient {
     /**
      * Exposes an instance of otp
      */
-    public var otps: OTP = OTPImpl()
-        private set
+    public val otps: OTP = OTPImpl()
         get() {
             assertInitialized()
             return field
@@ -108,8 +106,7 @@ public object StytchClient {
     /**
      * Exposes an instance of passwords
      */
-    public var passwords: Passwords = PasswordsImpl()
-        private set
+    public val passwords: Passwords = PasswordsImpl()
         get() {
             assertInitialized()
             return field
@@ -118,8 +115,7 @@ public object StytchClient {
     /**
      * Exposes an instance of sessions
      */
-    public var sessions: Sessions = SessionsImpl()
-        private set
+    public val sessions: Sessions = SessionsImpl()
         get() {
             assertInitialized()
             return field
@@ -133,8 +129,8 @@ public object StytchClient {
         this.ioDispatcher = ioDispatcher
     }
 
-//    TODO("OAuth")
-//    TODO("User Management")
+    // TODO("OAuth")
+    // TODO("User Management")
 
     private fun getDeviceInfo(context: Context): DeviceInfo {
         val deviceInfo = DeviceInfo()
@@ -144,7 +140,7 @@ public object StytchClient {
         deviceInfo.osName = Build.VERSION.CODENAME
 
         try {
-//          throw exceptions if packageName not found
+            // throw exceptions if packageName not found
             deviceInfo.applicationVersion = context
                 .applicationContext
                 .packageManager
@@ -211,7 +207,7 @@ public object StytchClient {
     ) {
         GlobalScope.launch(uiDispatcher) {
             val result = handle(uri, sessionDurationMinutes)
-//              change to main thread to call callback
+            // change to main thread to call callback
             callback(result)
         }
     }

--- a/sdk/src/main/java/com/stytch/sessions/SessionStorage.kt
+++ b/sdk/src/main/java/com/stytch/sessions/SessionStorage.kt
@@ -1,9 +1,6 @@
 package com.stytch.sessions
 
 import com.stytch.sdk.StytchClient
-import com.stytch.sdk.StytchExceptions
-import com.stytch.sdk.StytchResult
-import com.stytch.sdk.network.responseData.IAuthData
 import com.stytch.sdk.network.responseData.SessionData
 
 private const val PREFERENCES_NAME_SESSION_JWT = "session_jwt"
@@ -60,18 +57,4 @@ internal class SessionStorage {
             session = null
         }
     }
-}
-
-//    save session data
-internal fun <T : IAuthData> StytchResult<T>.saveSession(): StytchResult<T> {
-    if (this is StytchResult.Success) {
-        value.apply {
-            try {
-                StytchClient.sessionStorage.updateSession(sessionToken, sessionJwt, session)
-            } catch (ex: Exception) {
-                return StytchResult.Error(StytchExceptions.Critical(ex))
-            }
-        }
-    }
-    return this
 }


### PR DESCRIPTION
Linear Ticket: [SDK-613](https://linear.app/stytch/issue/SDK-613)

## Changes:

1. Move SessionImpl to sdk package for consistency
2. Move saveSession extension method to callers
3. Change StytchClient fields to val, since they are not re-set (or settable externally)
4. Clean up some comment formatting
5. Centralize the "externalscope" used in the feature implementations and pass them in as arguments (help with testing and potential replacement in future tickets)