### PR TITLE
Feature/SDK-622 Fix OkHttp charset issue

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/network/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/network/StytchApi.kt
@@ -84,6 +84,16 @@ internal object StytchApi {
                             return@Interceptor response
                         }
                     )
+                    .addNetworkInterceptor {
+                        // OkHttp is adding a charset to the content-type which is rejected by the API
+                        // see: https://github.com/square/okhttp/issues/3081
+                        it.proceed(
+                            it.request()
+                                .newBuilder()
+                                .header("Content-Type", "application/json")
+                                .build()
+                        )
+                    }
                     .build()
             )
             .build()


### PR DESCRIPTION
Linear Ticket: [SDK-622](https://linear.app/stytch/issue/SDK-622)

## Changes:

1. Add a network interceptor to explicitly set the content-type to stop OkHttp from automatically adding a charset which was causing failed API responses

## Notes:

- https://github.com/square/okhttp/issues/3081