### PR TITLE
SDK-631 Add tests for Biometrics and UserManagement requests

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/Biometrics.kt
+++ b/sdk/src/main/java/com/stytch/sdk/Biometrics.kt
@@ -18,48 +18,6 @@ public interface Biometrics {
     )
 
     /**
-     * Data class used for wrapping parameters used with Biometrics registration start flow
-     * @param publicKey Base64 encoded public key retrieved from SharedPreferences
-     */
-    public data class RegisterStartParameters(
-        val publicKey: String,
-    )
-
-    /**
-     * Data class used for wrapping parameters used with Biometrics registration flow
-     * @param signature Base64 encoded signed challenge
-     * @param biometricRegistrationId an identifier returned from the API to identify this request
-     * @param sessionDurationMinutes indicates how long the session should last before it expires
-     */
-    public data class RegisterParameters(
-        val signature: String,
-        val biometricRegistrationId: String,
-        val sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
-    )
-
-    /**
-     * Data class used for wrapping parameters used with Biometrics authentication start flow
-     * @param publicKey Base64 encoded public key retrieved from SharedPreferences
-     * @param sessionDurationMinutes indicates how long the session should last before it expires
-     */
-    public data class AuthenticateStartParameters(
-        val publicKey: String,
-        val sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
-    )
-
-    /**
-     * Data class used for wrapping parameters used with Biometrics authentication flow
-     * @param signature Base64 encoded signed challenge
-     * @param biometricRegistrationId an identifier returned from the API to identify this request
-     * @param sessionDurationMinutes indicates how long the session should last before it expires
-     */
-    public data class AuthenticateParameters(
-        val signature: String,
-        val biometricRegistrationId: String,
-        val sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
-    )
-
-    /**
      * Indicates if there is an existing biometric registration on device.
      */
     public val registrationAvailable: Boolean

--- a/sdk/src/test/java/com/stytch/sdk/BiometricsTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/BiometricsTest.kt
@@ -16,36 +16,4 @@ internal class BiometricsTest {
         )
         assert(params == expected)
     }
-
-    @Test
-    fun `Biometrics RegisterParameters have correct default values`() {
-        val params = Biometrics.RegisterParameters("signature", "biometricsRegistrationId")
-        val expected = Biometrics.RegisterParameters(
-            signature = "signature",
-            biometricRegistrationId = "biometricsRegistrationId",
-            sessionDurationMinutes = Constants.DEFAULT_SESSION_TIME_MINUTES,
-        )
-        assert(params == expected)
-    }
-
-    @Test
-    fun `Biometrics AuthenticateStartParameters have correct default values`() {
-        val params = Biometrics.AuthenticateStartParameters("publicKey")
-        val expected = Biometrics.AuthenticateStartParameters(
-            publicKey = "publicKey",
-            sessionDurationMinutes = Constants.DEFAULT_SESSION_TIME_MINUTES,
-        )
-        assert(params == expected)
-    }
-
-    @Test
-    fun `Biometrics AuthenticateParameters have correct default values`() {
-        val params = Biometrics.AuthenticateParameters("signature", "biometricsRegistrationId")
-        val expected = Biometrics.AuthenticateParameters(
-            signature = "signature",
-            biometricRegistrationId = "biometricsRegistrationId",
-            sessionDurationMinutes = Constants.DEFAULT_SESSION_TIME_MINUTES,
-        )
-        assert(params == expected)
-    }
 }

--- a/sdk/src/test/java/com/stytch/sdk/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/network/StytchApiServiceTests.kt
@@ -343,4 +343,144 @@ internal class StytchApiServiceTests {
     }
 
     // endregion Sessions
+
+    // region Biometrics
+    @Test
+    fun `check biometricsRegisterStart request`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(404))
+        runBlocking {
+            try {
+                apiService.biometricsRegisterStart(
+                    StytchRequests.Biometrics.RegisterStartRequest(publicKey = "publicKey")
+                )
+            } catch (_: Exception) {}
+            val request = mockWebServer.takeRequest()
+            val body = request.body.readUtf8()
+            assert(request.method == "POST")
+            assert(request.path == "/biometrics/register/start")
+            assert(body.contains("public_key\":\"publicKey\""))
+        }
+    }
+
+    @Test
+    fun `check biometricsRegister request`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(404))
+        runBlocking {
+            try {
+                apiService.biometricsRegister(
+                    StytchRequests.Biometrics.RegisterRequest(
+                        signature = "signature",
+                        biometricRegistrationId = "biometricRegistrationId",
+                        sessionDurationMinutes = 30
+                    )
+                )
+            } catch (_: Exception) {}
+            val request = mockWebServer.takeRequest()
+            val body = request.body.readUtf8()
+            assert(request.method == "POST")
+            assert(request.path == "/biometrics/register")
+            assert(body.contains("signature\":\"signature\""))
+            assert(body.contains("biometric_registration_id\":\"biometricRegistrationId\""))
+            assert(body.contains("session_duration_minutes\":30"))
+        }
+    }
+
+    @Test
+    fun `check biometricsAuthenticateStart request`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(404))
+        runBlocking {
+            try {
+                apiService.biometricsAuthenticateStart(
+                    StytchRequests.Biometrics.AuthenticateStartRequest(publicKey = "publicKey")
+                )
+            } catch (_: Exception) {}
+            val request = mockWebServer.takeRequest()
+            val body = request.body.readUtf8()
+            assert(request.method == "POST")
+            assert(request.path == "/biometrics/authenticate/start")
+            assert(body.contains("public_key\":\"publicKey\""))
+        }
+    }
+
+    @Test
+    fun `check biometricsAuthenticate request`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(404))
+        runBlocking {
+            try {
+                apiService.biometricsAuthenticate(
+                    StytchRequests.Biometrics.AuthenticateRequest(
+                        signature = "signature",
+                        biometricRegistrationId = "biometricRegistrationId",
+                        sessionDurationMinutes = 30
+                    )
+                )
+            } catch (_: Exception) {}
+            val request = mockWebServer.takeRequest()
+            val body = request.body.readUtf8()
+            assert(request.method == "POST")
+            assert(request.path == "/biometrics/authenticate")
+            assert(body.contains("signature\":\"signature\""))
+            assert(body.contains("biometric_registration_id\":\"biometricRegistrationId\""))
+            assert(body.contains("session_duration_minutes\":30"))
+        }
+    }
+    // endregion Biometrics
+
+    // region UserManagement
+    @Test
+    fun `check getUser request`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(404))
+        runBlocking {
+            try {
+                apiService.getUser()
+            } catch (_: Exception) {
+            }
+            val request = mockWebServer.takeRequest()
+            assert(request.method == "GET")
+            assert(request.path == "/users/me")
+        }
+    }
+
+    @Test
+    fun `check deleteEmailById request`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(404))
+        runBlocking {
+            try {
+                apiService.deleteEmailById("email_id")
+            } catch (_: Exception) {
+            }
+            val request = mockWebServer.takeRequest()
+            assert(request.method == "DELETE")
+            assert(request.path == "/users/emails/email_id")
+        }
+    }
+
+    @Test
+    fun `check deletePhoneNumberById request`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(404))
+        runBlocking {
+            try {
+                apiService.deletePhoneNumberById("phone_number_id")
+            } catch (_: Exception) {
+            }
+            val request = mockWebServer.takeRequest()
+            assert(request.method == "DELETE")
+            assert(request.path == "/users/phone_numbers/phone_number_id")
+        }
+    }
+
+    @Test
+    fun `check deleteBiometricRegistrationById request`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(404))
+        runBlocking {
+            try {
+                apiService.deleteBiometricRegistrationById("biometrics_registration_id")
+            } catch (_: Exception) {
+            }
+            val request = mockWebServer.takeRequest()
+            assert(request.method == "DELETE")
+            assert(request.path == "/users/biometric_registrations/biometrics_registration_id")
+        }
+    }
+    // endregion UserManagement
 }


### PR DESCRIPTION
Linear Ticket: [SDK-631](https://linear.app/stytch/issue/SDK-631)

## Changes:
1. Remove unused parameter classes from Biometrics (and associated tests)
2. Add tests for biometrics and usermanagement requests

## Notes:
- The unused parameter classes were created by me when I first started fleshing out the SDK endpoints before realizing that the relevant API calls were being made in code, and the developer would never interact with those endpoints directly.