### PR TITLE
Feature/SDK-687 Rotate SecretKey on invalidation

### DIFF
--- a/exampleapp/src/main/java/com/stytch/exampleapp/ui/BiometricsScreen.kt
+++ b/exampleapp/src/main/java/com/stytch/exampleapp/ui/BiometricsScreen.kt
@@ -40,7 +40,7 @@ fun BiometricsScreen(navController: NavController) {
         Text(
             text = stringResource(
                 R.string.biometrics_registration_exists,
-                StytchClient.biometrics.registrationAvailable,
+                StytchClient.biometrics.isRegistrationAvailable(context),
             )
         )
         if (biometricsAreAvailable) {

--- a/sdk/src/main/java/com/stytch/sdk/Biometrics.kt
+++ b/sdk/src/main/java/com/stytch/sdk/Biometrics.kt
@@ -36,7 +36,7 @@ public interface Biometrics {
     /**
      * Indicates if there is an existing biometric registration on device.
      */
-    public val registrationAvailable: Boolean
+    public fun isRegistrationAvailable(context: FragmentActivity): Boolean
 
     /**
      * Indicates if the biometric sensor is available, and provides a reasoning if not

--- a/sdk/src/main/java/com/stytch/sdk/BiometricsProvider.kt
+++ b/sdk/src/main/java/com/stytch/sdk/BiometricsProvider.kt
@@ -16,6 +16,7 @@ public enum class BiometricAvailability(public val message: String) {
     ),
     BIOMETRIC_ERROR_UNSUPPORTED("The requested biometrics options are incompatible with the current Android version."),
     BIOMETRIC_STATUS_UNKNOWN("Unable to determine whether the user can authenticate."),
+    BIOMETRICS_REVOKED("Biometric key was revoked. Must re-register a biometric authentication.")
 }
 
 internal interface BiometricsProvider {
@@ -31,4 +32,8 @@ internal interface BiometricsProvider {
     ): Cipher
 
     fun areBiometricsAvailable(context: FragmentActivity): BiometricAvailability
+
+    fun deleteSecretKey()
+
+    fun ensureSecretKeyIsAvailable()
 }

--- a/sdk/src/main/java/com/stytch/sdk/BiometricsProviderImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/BiometricsProviderImpl.kt
@@ -127,7 +127,7 @@ internal class BiometricsProviderImpl : BiometricsProvider {
     }
 
     override fun ensureSecretKeyIsAvailable() {
-        if (secretKey == null) error("SecertKey cannot be null")
+        if (secretKey == null) error("SecretKey cannot be null")
         // initialize a cipher (that we won't use) with the secretkey to ensure it hasn't been invalidated
         val cipher = getCipher()
         cipher.init(Cipher.ENCRYPT_MODE, secretKey)

--- a/sdk/src/main/java/com/stytch/sdk/BiometricsProviderImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/BiometricsProviderImpl.kt
@@ -74,11 +74,6 @@ internal class BiometricsProviderImpl : BiometricsProvider {
                     ?.let { continuation.resume(it) }
                     ?: continuation.resumeWithException(StytchExceptions.Input(AUTHENTICATION_FAILED))
             }
-
-            override fun onAuthenticationFailed() {
-                super.onAuthenticationFailed()
-                continuation.resumeWithException(StytchExceptions.Input(AUTHENTICATION_FAILED))
-            }
         }
         val prompt = promptInfo ?: BiometricPrompt.PromptInfo.Builder()
             .setTitle(context.getString(R.string.stytch_biometric_prompt_title))

--- a/sdk/src/test/java/com/stytch/sdk/BiometricsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/BiometricsImplTest.kt
@@ -123,6 +123,7 @@ internal class BiometricsImplTest {
         coEvery {
             mockBiometricsProvider.showBiometricPromptForRegistration(any(), any())
         } throws StytchExceptions.Input("Authentication failed")
+        every { mockBiometricsProvider.deleteSecretKey() } just runs
         val result = impl.register(mockk(relaxed = true))
         require(result is StytchResult.Error)
         assert(result.exception.reason == "Authentication failed")
@@ -141,6 +142,7 @@ internal class BiometricsImplTest {
         coEvery {
             mockBiometricsProvider.showBiometricPromptForRegistration(any(), any())
         } throws RuntimeException("Testing")
+        every { mockBiometricsProvider.deleteSecretKey() } just runs
         val result = impl.register(mockk(relaxed = true))
         require(result is StytchResult.Error)
         assert(result.exception.reason is RuntimeException)
@@ -403,6 +405,7 @@ internal class BiometricsImplTest {
         every { mockStorageHelper.deletePreference(any()) } returns true
         coEvery { mockUserManagerApi.deleteBiometricRegistrationById(any()) } returns mockk(relaxed = true)
         coEvery { deleteBiometricsSpy.invoke(any()) } just runs
+        every { mockBiometricsProvider.deleteSecretKey() } just runs
         assert(impl.removeRegistration())
         verify { mockStorageHelper.deletePreference(LAST_USED_BIOMETRIC_REGISTRATION_ID) }
         verify { mockStorageHelper.deletePreference(PRIVATE_KEY_KEY) }
@@ -413,6 +416,7 @@ internal class BiometricsImplTest {
     @Test
     fun `removeRegistration with callback calls callback`() {
         every { mockStorageHelper.deletePreference(any()) } returns true
+        every { mockBiometricsProvider.deleteSecretKey() } just runs
         val mockCallback = spyk<(Boolean) -> Unit>()
         impl.removeRegistration(mockCallback)
         verify { mockCallback.invoke(any()) }
@@ -427,6 +431,7 @@ internal class BiometricsImplTest {
 
     @Test
     fun `areBiometricsAvailable delegates to BiometricsProvider`() {
+        every { mockBiometricsProvider.ensureSecretKeyIsAvailable() } just runs
         every { mockBiometricsProvider.areBiometricsAvailable(any()) } returns BiometricAvailability.BIOMETRIC_SUCCESS
         val available = impl.areBiometricsAvailable(mockk())
         assert(available == BiometricAvailability.BIOMETRIC_SUCCESS)

--- a/sdk/src/test/java/com/stytch/sdk/BiometricsImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/BiometricsImplTest.kt
@@ -118,6 +118,8 @@ internal class BiometricsImplTest {
         every { mockStorageHelper.checkIfKeysetIsUsingKeystore() } returns true
         every { mockStorageHelper.loadValue(any()) } returns null
         every { mockStorageHelper.preferenceExists(any()) } returns true
+        every { mockBiometricsProvider.ensureSecretKeyIsAvailable() } just runs
+        every { mockBiometricsProvider.areBiometricsAvailable(any()) } returns BiometricAvailability.BIOMETRIC_SUCCESS
         every { mockStorageHelper.deletePreference(any()) } returns true
         every { mockSessionStorage.ensureSessionIsValidOrThrow() } just runs
         coEvery {
@@ -287,6 +289,8 @@ internal class BiometricsImplTest {
     @Test
     fun `authenticate returns correct error if biometrics fails`() = runTest {
         every { mockStorageHelper.preferenceExists(any()) } returns true
+        every { mockBiometricsProvider.ensureSecretKeyIsAvailable() } just runs
+        every { mockBiometricsProvider.areBiometricsAvailable(any()) } returns BiometricAvailability.BIOMETRIC_SUCCESS
         every { mockStorageHelper.loadValue(any()) } returns ""
         coEvery {
             mockBiometricsProvider.showBiometricPromptForAuthentication(any(), any(), any())
@@ -299,6 +303,8 @@ internal class BiometricsImplTest {
     @Test
     fun `authenticate returns correct error if public key cannot be derived from private key`() = runTest {
         every { mockStorageHelper.preferenceExists(any()) } returns true
+        every { mockBiometricsProvider.ensureSecretKeyIsAvailable() } just runs
+        every { mockBiometricsProvider.areBiometricsAvailable(any()) } returns BiometricAvailability.BIOMETRIC_SUCCESS
         every { mockStorageHelper.loadValue(any()) } returns ""
         coEvery {
             mockBiometricsProvider.showBiometricPromptForAuthentication(any(), any(), any())
@@ -314,6 +320,8 @@ internal class BiometricsImplTest {
     @Test
     fun `authenticate returns correct error if authenticateStart fails`() = runTest {
         every { mockStorageHelper.preferenceExists(any()) } returns true
+        every { mockBiometricsProvider.ensureSecretKeyIsAvailable() } just runs
+        every { mockBiometricsProvider.areBiometricsAvailable(any()) } returns BiometricAvailability.BIOMETRIC_SUCCESS
         every { mockStorageHelper.loadValue(any()) } returns ""
         coEvery {
             mockBiometricsProvider.showBiometricPromptForAuthentication(any(), any(), any())
@@ -333,6 +341,8 @@ internal class BiometricsImplTest {
     @Test
     fun `authenticate returns correct error if challenge signing fails`() = runTest {
         every { mockStorageHelper.preferenceExists(any()) } returns true
+        every { mockBiometricsProvider.ensureSecretKeyIsAvailable() } just runs
+        every { mockBiometricsProvider.areBiometricsAvailable(any()) } returns BiometricAvailability.BIOMETRIC_SUCCESS
         every { mockStorageHelper.loadValue(any()) } returns ""
         coEvery {
             mockBiometricsProvider.showBiometricPromptForAuthentication(any(), any(), any())
@@ -358,6 +368,8 @@ internal class BiometricsImplTest {
     @Test
     fun `authenticate returns success if everything succeeds`() = runTest {
         every { mockStorageHelper.preferenceExists(any()) } returns true
+        every { mockBiometricsProvider.ensureSecretKeyIsAvailable() } just runs
+        every { mockBiometricsProvider.areBiometricsAvailable(any()) } returns BiometricAvailability.BIOMETRIC_SUCCESS
         every { mockStorageHelper.loadValue(any()) } returns ""
         coEvery {
             mockBiometricsProvider.showBiometricPromptForAuthentication(any(), any(), any())
@@ -393,7 +405,9 @@ internal class BiometricsImplTest {
     @Test
     fun `registrationAvailable delegates to storageHelper`() {
         every { mockStorageHelper.preferenceExists(any()) } returns true
-        assert(impl.registrationAvailable)
+        every { mockBiometricsProvider.ensureSecretKeyIsAvailable() } just runs
+        every { mockBiometricsProvider.areBiometricsAvailable(any()) } returns BiometricAvailability.BIOMETRIC_SUCCESS
+        assert(impl.isRegistrationAvailable(mockk(relaxed = true)))
         verify { mockStorageHelper.preferenceExists(LAST_USED_BIOMETRIC_REGISTRATION_ID) }
         verify { mockStorageHelper.preferenceExists(PRIVATE_KEY_KEY) }
         verify { mockStorageHelper.preferenceExists(CIPHER_IV_KEY) }


### PR DESCRIPTION
Linear Ticket: [SDK-687](https://linear.app/stytch/issue/SDK-687)

## Changes:
1. Adds a check to areBiometricsAvailable method to determine if the SecretKey is still valid. If it's been invalidated, delete the existing registration and return a status of BIOMETRICS_REVOKED
2. Change secretKey to a getter instead of a onetime shot
3. Delete the secret key when deleting registrations