### PR TITLE
Feature/SDK-729 Support using device credentials in biometrics

### DIFF
--- a/exampleapp/src/main/java/com/stytch/exampleapp/BiometricsViewModel.kt
+++ b/exampleapp/src/main/java/com/stytch/exampleapp/BiometricsViewModel.kt
@@ -1,7 +1,6 @@
 package com.stytch.exampleapp
 
 import android.app.Application
-import androidx.biometric.BiometricPrompt.PromptInfo
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
@@ -21,13 +20,13 @@ class BiometricsViewModel(application: Application) : AndroidViewModel(applicati
     val loadingState: StateFlow<Boolean>
         get() = _loadingState
 
-    fun registerBiometrics(context: FragmentActivity, promptInfo: PromptInfo? = null) {
+    fun registerBiometrics(context: FragmentActivity, promptData: Biometrics.PromptData? = null) {
         viewModelScope.launch {
             _loadingState.value = true
             val result = StytchClient.biometrics.register(
                 Biometrics.RegisterParameters(
                     context = context,
-                    promptInfo = promptInfo,
+                    promptData = promptData,
                     allowFallbackToCleartext = false,
                     allowDeviceCredentials = true,
                 )
@@ -41,11 +40,11 @@ class BiometricsViewModel(application: Application) : AndroidViewModel(applicati
         }
     }
 
-    fun authenticateBiometrics(context: FragmentActivity, promptInfo: PromptInfo? = null) {
+    fun authenticateBiometrics(context: FragmentActivity, promptData: Biometrics.PromptData? = null) {
         viewModelScope.launch {
             _loadingState.value = true
             val result = StytchClient.biometrics.authenticate(
-                Biometrics.AuthenticateParameters(context = context, promptInfo = promptInfo)
+                Biometrics.AuthenticateParameters(context = context, promptData = promptData)
             )
             _currentResponse.value = when (result) {
                 is StytchResult.Success<*> -> result.toString()

--- a/exampleapp/src/main/java/com/stytch/exampleapp/BiometricsViewModel.kt
+++ b/exampleapp/src/main/java/com/stytch/exampleapp/BiometricsViewModel.kt
@@ -21,10 +21,6 @@ class BiometricsViewModel(application: Application) : AndroidViewModel(applicati
     val loadingState: StateFlow<Boolean>
         get() = _loadingState
 
-    fun showBiometricsError(error: String) {
-        _currentResponse.value = error
-    }
-
     fun registerBiometrics(context: FragmentActivity, promptInfo: PromptInfo? = null) {
         viewModelScope.launch {
             _loadingState.value = true
@@ -33,6 +29,7 @@ class BiometricsViewModel(application: Application) : AndroidViewModel(applicati
                     context = context,
                     promptInfo = promptInfo,
                     allowFallbackToCleartext = false,
+                    allowDeviceCredentials = true,
                 )
             )
             _currentResponse.value = when (result) {

--- a/exampleapp/src/main/java/com/stytch/exampleapp/ui/BiometricsScreen.kt
+++ b/exampleapp/src/main/java/com/stytch/exampleapp/ui/BiometricsScreen.kt
@@ -30,7 +30,7 @@ fun BiometricsScreen(navController: NavController) {
     val loading = viewModel.loadingState.collectAsState()
     val responseState = viewModel.currentResponse.collectAsState()
     val context = LocalContext.current as FragmentActivity
-    val biometricAvailability = StytchClient.biometrics.areBiometricsAvailable(context)
+    val biometricAvailability = StytchClient.biometrics.areBiometricsAvailable(context, true)
     val biometricsAreAvailable = biometricAvailability == BiometricAvailability.BIOMETRIC_SUCCESS
 
     Column(

--- a/sdk/src/main/java/com/stytch/sdk/Biometrics.kt
+++ b/sdk/src/main/java/com/stytch/sdk/Biometrics.kt
@@ -1,6 +1,5 @@
 package com.stytch.sdk
 
-import androidx.biometric.BiometricPrompt.PromptInfo
 import androidx.fragment.app.FragmentActivity
 
 /**
@@ -12,13 +11,13 @@ public interface Biometrics {
      * @param context is the calling FragmentActivity
      * @param sessionDurationMinutes indicates how long the session should last before it expires
      * @param allowFallbackToCleartext opts-in to potentially unsafe behavior
-     * @param promptInfo is an optional biometric prompt configuration. If one is not provided a default will be created
+     * @param promptData is an optional biometric prompt configuration. If one is not provided a default will be created
      */
     public data class RegisterParameters(
         val context: FragmentActivity,
         val sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
         val allowFallbackToCleartext: Boolean = false,
-        val promptInfo: PromptInfo? = null,
+        val promptData: PromptData? = null,
         val allowDeviceCredentials: Boolean = false,
     )
 
@@ -26,12 +25,21 @@ public interface Biometrics {
      * Data class used for wrapping parameters used with Biometrics authentication flow
      * @param context is the calling FragmentActivity
      * @param sessionDurationMinutes indicates how long the session should last before it expires
-     * @param promptInfo is an optional biometric prompt configuration. If one is not provided a default will be created
+     * @param promptData is an optional biometric prompt configuration. If one is not provided a default will be created
      */
     public data class AuthenticateParameters(
         val context: FragmentActivity,
         val sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
-        val promptInfo: PromptInfo? = null,
+        val promptData: PromptData? = null,
+    )
+
+    /**
+     * Data class used for wrapping parameters used to create a biometric prompt
+     */
+    public data class PromptData(
+        val title: String,
+        val subTitle: String,
+        val negativeButtonText: String
     )
 
     /**

--- a/sdk/src/main/java/com/stytch/sdk/Biometrics.kt
+++ b/sdk/src/main/java/com/stytch/sdk/Biometrics.kt
@@ -19,6 +19,7 @@ public interface Biometrics {
         val sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
         val allowFallbackToCleartext: Boolean = false,
         val promptInfo: PromptInfo? = null,
+        val allowDeviceCredentials: Boolean = false,
     )
 
     /**
@@ -41,7 +42,10 @@ public interface Biometrics {
     /**
      * Indicates if the biometric sensor is available, and provides a reasoning if not
      */
-    public fun areBiometricsAvailable(context: FragmentActivity): BiometricAvailability
+    public fun areBiometricsAvailable(
+        context: FragmentActivity,
+        allowDeviceCredentials: Boolean = false,
+    ): BiometricAvailability
 
     /**
      * Clears existing biometric registrations stored on device. Useful when removing a user from a given device.

--- a/sdk/src/main/java/com/stytch/sdk/BiometricsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/BiometricsImpl.kt
@@ -98,7 +98,7 @@ public class BiometricsImpl internal constructor(
                 val cipher = withContext(dispatchers.ui) {
                     biometricsProvider.showBiometricPromptForRegistration(
                         context = parameters.context,
-                        promptInfo = parameters.promptInfo,
+                        promptData = parameters.promptData,
                         allowedAuthenticators = allowedAuthenticators,
                     )
                 }
@@ -160,7 +160,7 @@ public class BiometricsImpl internal constructor(
                 val cipher = withContext(dispatchers.ui) {
                     biometricsProvider.showBiometricPromptForAuthentication(
                         context = parameters.context,
-                        promptInfo = parameters.promptInfo,
+                        promptData = parameters.promptData,
                         iv = iv.toBase64DecodedByteArray(),
                         allowedAuthenticators = allowedAuthenticators,
                     )

--- a/sdk/src/main/java/com/stytch/sdk/BiometricsImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/BiometricsImpl.kt
@@ -1,6 +1,9 @@
 package com.stytch.sdk
 
+import android.os.Build
 import android.security.keystore.KeyPermanentlyInvalidatedException
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
+import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
 import androidx.fragment.app.FragmentActivity
 import com.stytch.sdk.extensions.toBase64DecodedByteArray
 import com.stytch.sdk.extensions.toBase64EncodedString
@@ -15,10 +18,12 @@ import kotlinx.coroutines.withContext
 internal const val LAST_USED_BIOMETRIC_REGISTRATION_ID = "last_used_biometric_registration_id"
 internal const val PRIVATE_KEY_KEY = "biometrics_private_key"
 internal const val CIPHER_IV_KEY = "biometrics_cipher_iv"
+internal const val ALLOW_DEVICE_CREDENTIALS_KEY = "biometric_allow_device_credentials"
 private val KEYS_REQUIRED_FOR_REGISTRATION = listOf(
     LAST_USED_BIOMETRIC_REGISTRATION_ID,
     PRIVATE_KEY_KEY,
     CIPHER_IV_KEY,
+    ALLOW_DEVICE_CREDENTIALS_KEY
 )
 
 @Suppress("LongParameterList")
@@ -29,16 +34,26 @@ public class BiometricsImpl internal constructor(
     private val storageHelper: StorageHelper,
     private val api: StytchApi.Biometrics,
     private val biometricsProvider: BiometricsProvider,
-    private val deleteBiometricRegistraton: suspend (String) -> Unit,
+    private val deleteBiometricRegistration: suspend (String) -> Unit,
 ) : Biometrics {
+    private fun getAllowedAuthenticators(allowDeviceCredentials: Boolean) =
+        if (allowDeviceCredentials && Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
+            BIOMETRIC_STRONG or DEVICE_CREDENTIAL
+        } else {
+            BIOMETRIC_STRONG
+        }
     override fun isRegistrationAvailable(context: FragmentActivity): Boolean {
         return KEYS_REQUIRED_FOR_REGISTRATION.all { storageHelper.preferenceExists(it) } &&
             areBiometricsAvailable(context) != BiometricAvailability.BIOMETRICS_REVOKED
     }
 
-    override fun areBiometricsAvailable(context: FragmentActivity): BiometricAvailability {
+    override fun areBiometricsAvailable(
+        context: FragmentActivity,
+        allowDeviceCredentials: Boolean,
+    ): BiometricAvailability {
+        val allowedAuthenticators = getAllowedAuthenticators(allowDeviceCredentials)
         try {
-            biometricsProvider.ensureSecretKeyIsAvailable()
+            biometricsProvider.ensureSecretKeyIsAvailable(allowedAuthenticators)
         } catch (_: KeyPermanentlyInvalidatedException) {
             externalScope.launch(dispatchers.io) {
                 removeRegistration()
@@ -48,12 +63,12 @@ public class BiometricsImpl internal constructor(
             // Secret key is null/couldn't be created (likely because of missing biometric factor). Do nothing and fall
             // back to regular areBiometricsAvailable check for full information
         }
-        return biometricsProvider.areBiometricsAvailable(context)
+        return biometricsProvider.areBiometricsAvailable(context, allowedAuthenticators)
     }
 
     override suspend fun removeRegistration(): Boolean = withContext(dispatchers.io) {
         storageHelper.loadValue(LAST_USED_BIOMETRIC_REGISTRATION_ID)?.let {
-            deleteBiometricRegistraton(it)
+            deleteBiometricRegistration(it)
         }
         KEYS_REQUIRED_FOR_REGISTRATION.forEach { storageHelper.deletePreference(it) }
         biometricsProvider.deleteSecretKey()
@@ -79,10 +94,12 @@ public class BiometricsImpl internal constructor(
                     removeRegistration()
                 }
                 sessionStorage.ensureSessionIsValidOrThrow()
+                val allowedAuthenticators = getAllowedAuthenticators(parameters.allowDeviceCredentials)
                 val cipher = withContext(dispatchers.ui) {
                     biometricsProvider.showBiometricPromptForRegistration(
                         context = parameters.context,
-                        promptInfo = parameters.promptInfo
+                        promptInfo = parameters.promptInfo,
+                        allowedAuthenticators = allowedAuthenticators,
                     )
                 }
                 val (publicKey, privateKey) = EncryptionManager.generateEd25519KeyPair()
@@ -105,6 +122,7 @@ public class BiometricsImpl internal constructor(
                         )
                         storageHelper.saveValue(PRIVATE_KEY_KEY, encryptedPrivateKeyString)
                         storageHelper.saveValue(CIPHER_IV_KEY, cipher.iv.toBase64EncodedString())
+                        storageHelper.saveBoolean(ALLOW_DEVICE_CREDENTIALS_KEY, parameters.allowDeviceCredentials)
                     }
                     launchSessionUpdater(dispatchers, sessionStorage)
                 }
@@ -129,6 +147,8 @@ public class BiometricsImpl internal constructor(
     override suspend fun authenticate(parameters: Biometrics.AuthenticateParameters): BiometricsAuthResponse =
         withContext(dispatchers.io) {
             try {
+                val allowDeviceCredentials = storageHelper.getBoolean(ALLOW_DEVICE_CREDENTIALS_KEY)
+                val allowedAuthenticators = getAllowedAuthenticators(allowDeviceCredentials)
                 val encryptedPrivateKey = storageHelper.loadValue(PRIVATE_KEY_KEY)
                 val iv = storageHelper.loadValue(CIPHER_IV_KEY)
                 try {
@@ -142,6 +162,7 @@ public class BiometricsImpl internal constructor(
                         context = parameters.context,
                         promptInfo = parameters.promptInfo,
                         iv = iv.toBase64DecodedByteArray(),
+                        allowedAuthenticators = allowedAuthenticators,
                     )
                 }
                 val encryptedPrivateKeyBytes = encryptedPrivateKey.toBase64DecodedByteArray()

--- a/sdk/src/main/java/com/stytch/sdk/BiometricsProvider.kt
+++ b/sdk/src/main/java/com/stytch/sdk/BiometricsProvider.kt
@@ -22,13 +22,13 @@ public enum class BiometricAvailability(public val message: String) {
 internal interface BiometricsProvider {
     suspend fun showBiometricPromptForRegistration(
         context: FragmentActivity,
-        promptInfo: BiometricPrompt.PromptInfo? = null,
+        promptData: Biometrics.PromptData? = null,
         allowedAuthenticators: Int,
     ): Cipher
 
     suspend fun showBiometricPromptForAuthentication(
         context: FragmentActivity,
-        promptInfo: BiometricPrompt.PromptInfo? = null,
+        promptData: Biometrics.PromptData? = null,
         iv: ByteArray,
         allowedAuthenticators: Int,
     ): Cipher

--- a/sdk/src/main/java/com/stytch/sdk/BiometricsProvider.kt
+++ b/sdk/src/main/java/com/stytch/sdk/BiometricsProvider.kt
@@ -23,17 +23,19 @@ internal interface BiometricsProvider {
     suspend fun showBiometricPromptForRegistration(
         context: FragmentActivity,
         promptInfo: BiometricPrompt.PromptInfo? = null,
+        allowedAuthenticators: Int,
     ): Cipher
 
     suspend fun showBiometricPromptForAuthentication(
         context: FragmentActivity,
         promptInfo: BiometricPrompt.PromptInfo? = null,
         iv: ByteArray,
+        allowedAuthenticators: Int,
     ): Cipher
 
-    fun areBiometricsAvailable(context: FragmentActivity): BiometricAvailability
+    fun areBiometricsAvailable(context: FragmentActivity, allowedAuthenticators: Int): BiometricAvailability
 
     fun deleteSecretKey()
 
-    fun ensureSecretKeyIsAvailable()
+    fun ensureSecretKeyIsAvailable(allowedAuthenticators: Int)
 }

--- a/sdk/src/main/java/com/stytch/sdk/BiometricsProviderImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/BiometricsProviderImpl.kt
@@ -1,8 +1,10 @@
 package com.stytch.sdk
 
+import android.os.Build
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators
 import androidx.biometric.BiometricPrompt
 import androidx.biometric.BiometricPrompt.CryptoObject
 import androidx.fragment.app.FragmentActivity
@@ -21,28 +23,40 @@ private const val BIOMETRIC_KEY_NAME = "stytch_biometric_key"
 
 internal class BiometricsProviderImpl : BiometricsProvider {
     private val keyStore = KeyStore.getInstance("AndroidKeyStore")
-    private val secretKey: SecretKey?
-        get() = try {
-            if (!keyStore.containsAlias(BIOMETRIC_KEY_NAME)) {
-                val keyGenerator = KeyGenerator.getInstance(
-                    KeyProperties.KEY_ALGORITHM_AES,
-                    "AndroidKeyStore"
-                )
-                val keyGenParameterSpec = KeyGenParameterSpec.Builder(
-                    BIOMETRIC_KEY_NAME,
-                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
-                )
-                    .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
-                    .setUserAuthenticationRequired(true)
-                    .build()
-                keyGenerator.init(keyGenParameterSpec)
-                keyGenerator.generateKey()
-            }
-            keyStore.getKey(BIOMETRIC_KEY_NAME, null) as SecretKey
-        } catch (_: Exception) {
-            null
+    private fun allowedAuthenticatorsIncludeDeviceCredentials(allowedAuthenticators: Int) =
+        allowedAuthenticators == Authenticators.BIOMETRIC_STRONG or Authenticators.DEVICE_CREDENTIAL
+
+    private fun getSecretKey(allowedAuthenticators: Int): SecretKey? = try {
+        if (!keyStore.containsAlias(BIOMETRIC_KEY_NAME)) {
+            val keyGenerator = KeyGenerator.getInstance(
+                KeyProperties.KEY_ALGORITHM_AES,
+                "AndroidKeyStore"
+            )
+            val keyGenParameterSpec = KeyGenParameterSpec.Builder(
+                BIOMETRIC_KEY_NAME,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            ).apply {
+                setBlockModes(KeyProperties.BLOCK_MODE_CBC)
+                setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                setUserAuthenticationRequired(true)
+                if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
+                    val authenticationParameters =
+                        if (allowedAuthenticatorsIncludeDeviceCredentials(allowedAuthenticators)) {
+                            KeyProperties.AUTH_BIOMETRIC_STRONG or KeyProperties.AUTH_DEVICE_CREDENTIAL
+                        } else {
+                            KeyProperties.AUTH_BIOMETRIC_STRONG
+                        }
+                    setUserAuthenticationParameters(0, authenticationParameters)
+                }
+                build()
+            }.build()
+            keyGenerator.init(keyGenParameterSpec)
+            keyGenerator.generateKey()
         }
+        keyStore.getKey(BIOMETRIC_KEY_NAME, null) as SecretKey
+    } catch (_: Exception) {
+        null
+    }
 
     init {
         keyStore.load(null)
@@ -60,6 +74,7 @@ internal class BiometricsProviderImpl : BiometricsProvider {
         context: FragmentActivity,
         promptInfo: BiometricPrompt.PromptInfo?,
         cipher: Cipher,
+        allowedAuthenticators: Int,
     ): Cipher = suspendCoroutine { continuation ->
         val executor = Executors.newSingleThreadExecutor()
         val callback = object : BiometricPrompt.AuthenticationCallback() {
@@ -75,36 +90,42 @@ internal class BiometricsProviderImpl : BiometricsProvider {
                     ?: continuation.resumeWithException(StytchExceptions.Input(AUTHENTICATION_FAILED))
             }
         }
-        val prompt = promptInfo ?: BiometricPrompt.PromptInfo.Builder()
-            .setTitle(context.getString(R.string.stytch_biometric_prompt_title))
-            .setSubtitle(context.getString(R.string.stytch_biometric_prompt_subtitle))
-            .setNegativeButtonText(context.getString(R.string.stytch_biometric_prompt_negative))
-            .build()
+        val prompt = promptInfo ?: BiometricPrompt.PromptInfo.Builder().apply {
+            setTitle(context.getString(R.string.stytch_biometric_prompt_title))
+            setSubtitle(context.getString(R.string.stytch_biometric_prompt_subtitle))
+            setAllowedAuthenticators(allowedAuthenticators)
+            if (!allowedAuthenticatorsIncludeDeviceCredentials(allowedAuthenticators)) {
+                // can only show negative button if device credentials are not allowed
+                setNegativeButtonText(context.getString(R.string.stytch_biometric_prompt_negative))
+            }
+        }.build()
         BiometricPrompt(context, executor, callback).authenticate(prompt, CryptoObject(cipher))
     }
 
     override suspend fun showBiometricPromptForRegistration(
         context: FragmentActivity,
         promptInfo: BiometricPrompt.PromptInfo?,
+        allowedAuthenticators: Int,
     ): Cipher {
         val cipher = getCipher()
-        cipher.init(Cipher.ENCRYPT_MODE, secretKey)
-        return showBiometricPrompt(context, promptInfo, cipher)
+        cipher.init(Cipher.ENCRYPT_MODE, getSecretKey(allowedAuthenticators))
+        return showBiometricPrompt(context, promptInfo, cipher, allowedAuthenticators)
     }
 
     override suspend fun showBiometricPromptForAuthentication(
         context: FragmentActivity,
         promptInfo: BiometricPrompt.PromptInfo?,
         iv: ByteArray,
+        allowedAuthenticators: Int,
     ): Cipher {
         val cipher = getCipher()
-        cipher.init(Cipher.DECRYPT_MODE, secretKey, IvParameterSpec(iv))
-        return showBiometricPrompt(context, promptInfo, cipher)
+        cipher.init(Cipher.DECRYPT_MODE, getSecretKey(allowedAuthenticators), IvParameterSpec(iv))
+        return showBiometricPrompt(context, promptInfo, cipher, allowedAuthenticators)
     }
 
-    override fun areBiometricsAvailable(context: FragmentActivity): BiometricAvailability {
+    override fun areBiometricsAvailable(context: FragmentActivity, allowedAuthenticators: Int): BiometricAvailability {
         val biometricManager = BiometricManager.from(context)
-        return when (biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG)) {
+        return when (biometricManager.canAuthenticate(allowedAuthenticators)) {
             BiometricManager.BIOMETRIC_SUCCESS -> BiometricAvailability.BIOMETRIC_SUCCESS
             BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE -> BiometricAvailability.BIOMETRIC_ERROR_NO_HARDWARE
             BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE -> BiometricAvailability.BIOMETRIC_ERROR_HW_UNAVAILABLE
@@ -121,8 +142,8 @@ internal class BiometricsProviderImpl : BiometricsProvider {
         keyStore.deleteEntry(BIOMETRIC_KEY_NAME)
     }
 
-    override fun ensureSecretKeyIsAvailable() {
-        if (secretKey == null) error("SecretKey cannot be null")
+    override fun ensureSecretKeyIsAvailable(allowedAuthenticators: Int,) {
+        val secretKey = getSecretKey(allowedAuthenticators) ?: error("SecretKey cannot be null")
         // initialize a cipher (that we won't use) with the secretkey to ensure it hasn't been invalidated
         val cipher = getCipher()
         cipher.init(Cipher.ENCRYPT_MODE, secretKey)

--- a/sdk/src/main/java/com/stytch/sdk/StorageHelper.kt
+++ b/sdk/src/main/java/com/stytch/sdk/StorageHelper.kt
@@ -39,6 +39,15 @@ internal object StorageHelper {
         }
     }
 
+    internal fun saveBoolean(name: String, value: Boolean) {
+        with(sharedPreferences.edit()) {
+            putBoolean(name, value)
+            apply()
+        }
+    }
+
+    internal fun getBoolean(name: String): Boolean = sharedPreferences.getBoolean(name, false)
+
     /**
      * Load and decrypt value from SharedPreferences
      * @return null if failed to load data

--- a/sdk/src/test/java/com/stytch/sdk/BiometricsTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/BiometricsTest.kt
@@ -13,7 +13,7 @@ internal class BiometricsTest {
             context = mockContext,
             sessionDurationMinutes = Constants.DEFAULT_SESSION_TIME_MINUTES,
             allowFallbackToCleartext = false,
-            promptInfo = null,
+            promptData = null,
         )
         assert(params == expected)
     }


### PR DESCRIPTION
Linear Ticket: [SDK-729](https://linear.app/stytch/issue/SDK-729)

## Changes:
1. Add allowDeviceCredentials parameter to RegisterParameters. If true, and we are on API30+, allow using the "device credentials" (PIN/Pattern). Defaults to false.
2. Update biometric prompt to respect the above configuration
3. Update SecretKey generation to respect the above configuration
4. Fix typos
5. Change how customers can configure the biometric prompt (must pass in the raw data, not a preconfigured prompt) **This is a breaking change**

## Notes:
- The change in how the prompt is configured brings it more inline with how ReactNative handles it, and is necessary because we can't rely on the customer to properly configure the prompt before passing it in, especially with the new checks for device credentials. This was an oversight in the initial implementation.