### PR TITLE
SDK-754 Enable Password Reset deeplink handler

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 ext {
   PUBLISH_GROUP_ID = 'com.stytch.sdk'
-  PUBLISH_VERSION = '0.7.0'
+  PUBLISH_VERSION = '0.8.0'
   PUBLISH_ARTIFACT_ID = 'sdk'
 }
 

--- a/sdk/src/main/java/com/stytch/sdk/DeeplinkHandledStatus.kt
+++ b/sdk/src/main/java/com/stytch/sdk/DeeplinkHandledStatus.kt
@@ -1,0 +1,7 @@
+package com.stytch.sdk
+
+public sealed interface DeeplinkHandledStatus {
+    public data class Handled(val response: AuthResponse) : DeeplinkHandledStatus
+    public data class NotHandled(val reason: String) : DeeplinkHandledStatus
+    public data class ManualHandlingRequired(val type: TokenType, val token: String) : DeeplinkHandledStatus
+}

--- a/sdk/src/main/java/com/stytch/sdk/StytchClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/StytchClient.kt
@@ -260,7 +260,7 @@ public object StytchClient {
      * Handle magic link
      * @param uri - intent.data from deep link
      * @param sessionDurationMinutes - sessionDuration
-     * @return AuthResponse from backend after calling any of the authentication methods
+     * @return DeeplinkHandledStatus from backend after calling any of the authentication methods
      */
     public suspend fun handle(uri: Uri, sessionDurationMinutes: UInt): DeeplinkHandledStatus {
         assertInitialized()
@@ -294,7 +294,7 @@ public object StytchClient {
      * Handle magic link
      * @param uri - intent.data from deep link
      * @param sessionDurationMinutes - sessionDuration
-     * @param callback calls callback with AuthResponse response from backend
+     * @param callback calls callback with DeeplinkHandledStatus response from backend
      */
     public fun handle(
         uri: Uri,

--- a/sdk/src/main/java/com/stytch/sdk/StytchClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/StytchClient.kt
@@ -10,6 +10,7 @@ import com.stytch.sdk.biometrics.BiometricsProviderImpl
 import com.stytch.sdk.magicLinks.MagicLinks
 import com.stytch.sdk.magicLinks.MagicLinksImpl
 import com.stytch.sdk.network.StytchApi
+import com.stytch.sdk.network.StytchErrorType
 import com.stytch.sdk.network.responseData.BasicData
 import com.stytch.sdk.network.responseData.BiometricsAuthData
 import com.stytch.sdk.network.responseData.CreateResponse
@@ -261,32 +262,32 @@ public object StytchClient {
      * @param sessionDurationMinutes - sessionDuration
      * @return AuthResponse from backend after calling any of the authentication methods
      */
-    public suspend fun handle(uri: Uri, sessionDurationMinutes: UInt): AuthResponse {
+    public suspend fun handle(uri: Uri, sessionDurationMinutes: UInt): DeeplinkHandledStatus {
         assertInitialized()
-        val result: AuthResponse
-        withContext(dispatchers.io) {
+        return withContext(dispatchers.io) {
             val token = uri.getQueryParameter(Constants.QUERY_TOKEN)
             if (token.isNullOrEmpty()) {
-                result = StytchResult.Error(StytchExceptions.Input("Magic link missing token"))
-                return@withContext
+                return@withContext DeeplinkHandledStatus.NotHandled(StytchErrorType.DEEPLINK_MISSING_TOKEN.message)
             }
-            result = when (TokenType.fromString(uri.getQueryParameter(Constants.QUERY_TOKEN_TYPE))) {
+            when (TokenType.fromString(uri.getQueryParameter(Constants.QUERY_TOKEN_TYPE))) {
                 TokenType.MAGIC_LINKS -> {
-                    magicLinks.authenticate(MagicLinks.AuthParameters(token, sessionDurationMinutes))
+                    DeeplinkHandledStatus.Handled(
+                        magicLinks.authenticate(MagicLinks.AuthParameters(token, sessionDurationMinutes))
+                    )
                 }
                 TokenType.OAUTH -> {
-                    oauth.authenticate(OAuth.ThirdParty.AuthenticateParameters(token, sessionDurationMinutes))
+                    DeeplinkHandledStatus.Handled(
+                        oauth.authenticate(OAuth.ThirdParty.AuthenticateParameters(token, sessionDurationMinutes))
+                    )
                 }
                 TokenType.PASSWORD_RESET -> {
-                    TODO("Implement password reset handling")
+                    DeeplinkHandledStatus.ManualHandlingRequired(type = TokenType.PASSWORD_RESET, token = token)
                 }
                 TokenType.UNKNOWN -> {
-                    StytchResult.Error(StytchExceptions.Input("Unknown magic link type"))
+                    DeeplinkHandledStatus.NotHandled(StytchErrorType.DEEPLINK_UNKNOWN_TOKEN.message)
                 }
             }
         }
-
-        return result
     }
 
     /**
@@ -298,7 +299,7 @@ public object StytchClient {
     public fun handle(
         uri: Uri,
         sessionDurationMinutes: UInt,
-        callback: (response: AuthResponse) -> Unit
+        callback: (response: DeeplinkHandledStatus) -> Unit
     ) {
         externalScope.launch(dispatchers.ui) {
             val result = handle(uri, sessionDurationMinutes)

--- a/sdk/src/main/java/com/stytch/sdk/TokenType.kt
+++ b/sdk/src/main/java/com/stytch/sdk/TokenType.kt
@@ -2,13 +2,13 @@ package com.stytch.sdk
 
 import java.util.Locale
 
-internal enum class TokenType {
+public enum class TokenType {
     MAGIC_LINKS,
     OAUTH,
     PASSWORD_RESET,
     UNKNOWN;
 
-    companion object {
+    internal companion object {
         fun fromString(typeString: String?): TokenType {
             return try {
                 valueOf(typeString?.uppercase(Locale.ENGLISH)!!)

--- a/sdk/src/main/java/com/stytch/sdk/network/StytchErrorType.kt
+++ b/sdk/src/main/java/com/stytch/sdk/network/StytchErrorType.kt
@@ -58,5 +58,13 @@ public enum class StytchErrorType(
     OAUTH_MISSING_PKCE(
         stringValue = "oauth_missing_pkce",
         message = "Unable to retrieve the PKCE challenge. This flow must be completed on the same device on which it was started", // ktlint-disable maximum-line-length
+    ),
+    DEEPLINK_MISSING_TOKEN(
+        stringValue = "deeplink_missing_token",
+        message = "Magic link missing token"
+    ),
+    DEEPLINK_UNKNOWN_TOKEN(
+        stringValue = "deeplink_unknown_token",
+        message = "Unknown magic link type"
     )
 }

--- a/sdk/src/main/java/com/stytch/sdk/network/StytchErrorType.kt
+++ b/sdk/src/main/java/com/stytch/sdk/network/StytchErrorType.kt
@@ -61,10 +61,10 @@ public enum class StytchErrorType(
     ),
     DEEPLINK_MISSING_TOKEN(
         stringValue = "deeplink_missing_token",
-        message = "Magic link missing token"
+        message = "Deeplink missing token"
     ),
     DEEPLINK_UNKNOWN_TOKEN(
         stringValue = "deeplink_unknown_token",
-        message = "Unknown magic link type"
+        message = "Unknown deeplink type"
     )
 }


### PR DESCRIPTION
Linear Ticket: [SDK-754](https://linear.app/stytch/issue/SDK-754)

## Changes:

1. Update `handle()` method to return a (new) `DeeplinkHandledStatus` type
2. Return correct data class for password reset deeplinks
3. Update tests

## Notes:

- This is more in alignment with how iOS handles deeplinks