### PR TITLE
Feature/SDK-749 Request testing improvements

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,64 +2,8 @@ Linear Ticket: [LINEAR_NUMBER](https://linear.app/stytch/issue/YOUR_TICKET)
 
 ## Changes:
 
-1.
-
 1. 
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
-
-1.
 
 ## Notes:
 
--
-
--
-
--
-
--
-
--
-
--
-
--
-
--
-
--
-
--
+- 

--- a/sdk/src/test/java/com/stytch/sdk/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/network/StytchApiServiceTests.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.utils.verifyPost
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
 import okio.EOFException
 import org.junit.After
 import org.junit.Before
@@ -45,8 +46,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.loginOrCreateUserByEmail(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/magic_links/email/login_or_create",
                 expectedBody = mapOf(
                     "email" to parameters.email,
@@ -68,8 +68,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.authenticate(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/magic_links/authenticate",
                 expectedBody = mapOf(
                     "token" to parameters.token,
@@ -92,8 +91,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.loginOrCreateUserByOTPWithEmail(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/otps/email/login_or_create",
                 expectedBody = mapOf(
                     "email" to parameters.email,
@@ -112,8 +110,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.loginOrCreateUserByOTPWithSMS(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/otps/sms/login_or_create",
                 expectedBody = mapOf(
                     "phone_number" to parameters.phoneNumber,
@@ -132,8 +129,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.loginOrCreateUserByOTPWithWhatsApp(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/otps/whatsapp/login_or_create",
                 expectedBody = mapOf(
                     "phone_number" to parameters.phoneNumber,
@@ -153,8 +149,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.authenticateWithOTP(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/otps/authenticate",
                 expectedBody = mapOf(
                     "token" to parameters.token,
@@ -179,8 +174,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.passwords(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/passwords",
                 expectedBody = mapOf(
                     "email" to parameters.email,
@@ -200,8 +194,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.strengthCheck(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/passwords/strength_check",
                 expectedBody = mapOf(
                     "email" to parameters.email,
@@ -222,8 +215,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.resetByEmail(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/passwords/email/reset",
                 expectedBody = mapOf(
                     "token" to parameters.token,
@@ -249,8 +241,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.resetByEmailStart(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/passwords/email/reset/start",
                 expectedBody = mapOf(
                     "email" to parameters.email,
@@ -275,8 +266,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.authenticateWithPasswords(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/passwords/authenticate",
                 expectedBody = mapOf(
                     "email" to parameters.email,
@@ -297,8 +287,7 @@ internal class StytchApiServiceTests {
             val parameters = StytchRequests.Sessions.AuthenticateRequest(24)
             requestIgnoringResponseException {
                 apiService.authenticateSessions(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/sessions/authenticate",
                 expectedBody = mapOf("session_duration_minutes" to parameters.sessionDurationMinutes)
             )
@@ -310,8 +299,7 @@ internal class StytchApiServiceTests {
         runBlocking {
             requestIgnoringResponseException {
                 apiService.revokeSessions()
-            }
-            mockWebServer.takeRequest().verifyPost(expectedPath = "/sessions/revoke")
+            }.verifyPost(expectedPath = "/sessions/revoke")
         }
     }
 
@@ -324,8 +312,7 @@ internal class StytchApiServiceTests {
             val parameters = StytchRequests.Biometrics.RegisterStartRequest(publicKey = "publicKey")
             requestIgnoringResponseException {
                 apiService.biometricsRegisterStart(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/biometrics/register/start",
                 expectedBody = mapOf("public_key" to parameters.publicKey)
             )
@@ -342,8 +329,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.biometricsRegister(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/biometrics/register",
                 expectedBody = mapOf(
                     "signature" to parameters.signature,
@@ -360,8 +346,7 @@ internal class StytchApiServiceTests {
             val parameters = StytchRequests.Biometrics.AuthenticateStartRequest(publicKey = "publicKey")
             requestIgnoringResponseException {
                 apiService.biometricsAuthenticateStart(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/biometrics/authenticate/start",
                 expectedBody = mapOf("public_key" to parameters.publicKey)
             )
@@ -378,8 +363,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.biometricsAuthenticate(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/biometrics/authenticate",
                 expectedBody = mapOf(
                     "signature" to parameters.signature,
@@ -397,8 +381,7 @@ internal class StytchApiServiceTests {
         runBlocking {
             requestIgnoringResponseException {
                 apiService.getUser()
-            }
-            mockWebServer.takeRequest().verifyGet("/users/me")
+            }.verifyGet("/users/me")
         }
     }
 
@@ -407,8 +390,7 @@ internal class StytchApiServiceTests {
         runBlocking {
             requestIgnoringResponseException {
                 apiService.deleteEmailById("email_id")
-            }
-            mockWebServer.takeRequest().verifyDelete("/users/emails/email_id")
+            }.verifyDelete("/users/emails/email_id")
         }
     }
 
@@ -417,8 +399,7 @@ internal class StytchApiServiceTests {
         runBlocking {
             requestIgnoringResponseException {
                 apiService.deletePhoneNumberById("phone_number_id")
-            }
-            mockWebServer.takeRequest().verifyDelete("/users/phone_numbers/phone_number_id")
+            }.verifyDelete("/users/phone_numbers/phone_number_id")
         }
     }
 
@@ -427,8 +408,7 @@ internal class StytchApiServiceTests {
         runBlocking {
             requestIgnoringResponseException {
                 apiService.deleteBiometricRegistrationById("biometrics_registration_id")
-            }
-            mockWebServer.takeRequest().verifyDelete("/users/biometric_registrations/biometrics_registration_id")
+            }.verifyDelete("/users/biometric_registrations/biometrics_registration_id")
         }
     }
 
@@ -437,8 +417,7 @@ internal class StytchApiServiceTests {
         runBlocking {
             requestIgnoringResponseException {
                 apiService.deleteCryptoWalletById("crypto_wallet_id")
-            }
-            mockWebServer.takeRequest().verifyDelete("/users/crypto_wallets/crypto_wallet_id")
+            }.verifyDelete("/users/crypto_wallets/crypto_wallet_id")
         }
     }
 
@@ -447,8 +426,7 @@ internal class StytchApiServiceTests {
         runBlocking {
             requestIgnoringResponseException {
                 apiService.deleteWebAuthnById("webauthn_registration_id")
-            }
-            mockWebServer.takeRequest().verifyDelete("/users/webauthn_registrations/webauthn_registration_id")
+            }.verifyDelete("/users/webauthn_registrations/webauthn_registration_id")
         }
     }
     // endregion UserManagement
@@ -464,8 +442,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.authenticateWithGoogleIdToken(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/oauth/google/id_token/authenticate",
                 expectedBody = mapOf(
                     "id_token" to parameters.idToken,
@@ -486,8 +463,7 @@ internal class StytchApiServiceTests {
             )
             requestIgnoringResponseException {
                 apiService.authenticateWithThirdPartyToken(parameters)
-            }
-            mockWebServer.takeRequest().verifyPost(
+            }.verifyPost(
                 expectedPath = "/oauth/authenticate",
                 expectedBody = mapOf(
                     "token" to parameters.token,
@@ -499,9 +475,12 @@ internal class StytchApiServiceTests {
     }
     // endregion OAuth
 
-    private suspend fun requestIgnoringResponseException(block: suspend () -> Unit) = try {
-        block()
-    } catch (_: EOFException) {
-        // OkHTTP throws EOFException because it expects a response body, but we're intentionally not creating them
+    private suspend fun requestIgnoringResponseException(block: suspend () -> Unit): RecordedRequest {
+        try {
+            block()
+        } catch (_: EOFException) {
+            // OkHTTP throws EOFException because it expects a response body, but we're intentionally not creating them
+        }
+        return mockWebServer.takeRequest()
     }
 }

--- a/sdk/src/test/java/com/stytch/sdk/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/network/StytchApiServiceTests.kt
@@ -459,7 +459,11 @@ internal class StytchApiServiceTests {
             val parameters = StytchRequests.OAuth.ThirdParty.AuthenticateRequest(
                 token = "id_token",
                 sessionDurationMinutes = 30,
-                codeVerifier = "code_challenge"
+                codeVerifier = "code_challenge",
+                sessionCustomClaims = mapOf(
+                    "custom_claim_1" to "custom_claim_1_value",
+                    "custom_claim_2" to "custom_claim_2_value",
+                )
             )
             requestIgnoringResponseException {
                 apiService.authenticateWithThirdPartyToken(parameters)
@@ -468,7 +472,8 @@ internal class StytchApiServiceTests {
                 expectedBody = mapOf(
                     "token" to parameters.token,
                     "session_duration_minutes" to parameters.sessionDurationMinutes,
-                    "code_verifier" to parameters.codeVerifier
+                    "code_verifier" to parameters.codeVerifier,
+                    "session_custom_claims" to parameters.sessionCustomClaims
                 )
             )
         }

--- a/sdk/src/test/java/com/stytch/sdk/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/network/StytchApiServiceTests.kt
@@ -39,10 +39,10 @@ internal class StytchApiServiceTests {
     fun `check magic links email loginOrCreate request`() {
         runBlocking {
             val parameters = StytchRequests.MagicLinks.Email.LoginOrCreateUserRequest(
-                EMAIL,
-                LOGIN_MAGIC_LINK,
-                "123",
-                "method2"
+                email = EMAIL,
+                loginMagicLinkUrl = LOGIN_MAGIC_LINK,
+                codeChallenge = "123",
+                codeChallengeMethod = "method2"
             )
             requestIgnoringResponseException {
                 apiService.loginOrCreateUserByEmail(parameters)
@@ -62,9 +62,9 @@ internal class StytchApiServiceTests {
     fun `check magic links authenticate request`() {
         runBlocking {
             val parameters = StytchRequests.MagicLinks.AuthenticateRequest(
-                "token",
-                "123",
-                60
+                token = "token",
+                codeVerifier = "123",
+                sessionDurationMinutes = 60
             )
             requestIgnoringResponseException {
                 apiService.authenticate(parameters)
@@ -86,8 +86,8 @@ internal class StytchApiServiceTests {
     fun `check OTP email loginOrCreate with default expiration request`() {
         runBlocking {
             val parameters = StytchRequests.OTP.Email(
-                EMAIL,
-                60
+                email = EMAIL,
+                expirationMinutes = 60
             )
             requestIgnoringResponseException {
                 apiService.loginOrCreateUserByOTPWithEmail(parameters)
@@ -105,8 +105,8 @@ internal class StytchApiServiceTests {
     fun `check OTP sms loginOrCreate request`() {
         runBlocking {
             val parameters = StytchRequests.OTP.SMS(
-                "000",
-                24
+                phoneNumber = "000",
+                expirationMinutes = 24
             )
             requestIgnoringResponseException {
                 apiService.loginOrCreateUserByOTPWithSMS(parameters)
@@ -124,8 +124,8 @@ internal class StytchApiServiceTests {
     fun `check OTP whatsapp loginOrCreate with default expiration request`() {
         runBlocking {
             val parameters = StytchRequests.OTP.WhatsApp(
-                "000",
-                60
+                phoneNumber = "000",
+                expirationMinutes = 60
             )
             requestIgnoringResponseException {
                 apiService.loginOrCreateUserByOTPWithWhatsApp(parameters)
@@ -143,9 +143,9 @@ internal class StytchApiServiceTests {
     fun `check OTP authenticate request`() {
         runBlocking {
             val parameters = StytchRequests.OTP.Authenticate(
-                "token",
-                "methodId",
-                60
+                token = "token",
+                methodId = "methodId",
+                sessionDurationMinutes = 60
             )
             requestIgnoringResponseException {
                 apiService.authenticateWithOTP(parameters)
@@ -168,9 +168,9 @@ internal class StytchApiServiceTests {
     fun `check Passwords create request`() {
         runBlocking {
             val parameters = StytchRequests.Passwords.CreateRequest(
-                EMAIL,
-                "123asd",
-                60
+                email = EMAIL,
+                password = "123asd",
+                sessionDurationMinutes = 60
             )
             requestIgnoringResponseException {
                 apiService.passwords(parameters)
@@ -189,8 +189,8 @@ internal class StytchApiServiceTests {
     fun `check Passwords strenghtCheck request`() {
         runBlocking {
             val parameters = StytchRequests.Passwords.StrengthCheckRequest(
-                EMAIL,
-                "123asd"
+                email = EMAIL,
+                password = "123asd"
             )
             requestIgnoringResponseException {
                 apiService.strengthCheck(parameters)
@@ -208,10 +208,10 @@ internal class StytchApiServiceTests {
     fun `check Passwords resetbyEmail request`() {
         runBlocking {
             val parameters = StytchRequests.Passwords.ResetByEmailRequest(
-                "token",
-                "123asd",
-                60,
-                "ver1"
+                token = "token",
+                password = "123asd",
+                sessionDurationMinutes = 60,
+                codeVerifier = "ver1"
             )
             requestIgnoringResponseException {
                 apiService.resetByEmail(parameters)
@@ -231,13 +231,13 @@ internal class StytchApiServiceTests {
     fun `check Passwords resetbyEmailStart request`() {
         runBlocking {
             val parameters = StytchRequests.Passwords.ResetByEmailStartRequest(
-                EMAIL,
-                "123",
-                "method2",
-                "loginRedirect",
-                24,
-                "resetPasswordUrl",
-                23
+                email = EMAIL,
+                codeChallenge = "123",
+                codeChallengeMethod = "method2",
+                loginRedirectUrl = "loginRedirect",
+                loginExpirationMinutes = 24,
+                resetPasswordRedirectUrl = "resetPasswordUrl",
+                resetPasswordExpirationMinutes = 23
             )
             requestIgnoringResponseException {
                 apiService.resetByEmailStart(parameters)
@@ -260,9 +260,9 @@ internal class StytchApiServiceTests {
     fun `check Passwords authenticate request`() {
         runBlocking {
             val parameters = StytchRequests.Passwords.AuthenticateRequest(
-                EMAIL,
-                "123asd",
-                46
+                email = EMAIL,
+                password = "123asd",
+                sessionDurationMinutes = 46
             )
             requestIgnoringResponseException {
                 apiService.authenticateWithPasswords(parameters)
@@ -284,7 +284,7 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Sessions authenticate request`() {
         runBlocking {
-            val parameters = StytchRequests.Sessions.AuthenticateRequest(24)
+            val parameters = StytchRequests.Sessions.AuthenticateRequest(sessionDurationMinutes = 24)
             requestIgnoringResponseException {
                 apiService.authenticateSessions(parameters)
             }.verifyPost(
@@ -389,7 +389,7 @@ internal class StytchApiServiceTests {
     fun `check deleteEmailById request`() {
         runBlocking {
             requestIgnoringResponseException {
-                apiService.deleteEmailById("email_id")
+                apiService.deleteEmailById(id = "email_id")
             }.verifyDelete("/users/emails/email_id")
         }
     }
@@ -398,7 +398,7 @@ internal class StytchApiServiceTests {
     fun `check deletePhoneNumberById request`() {
         runBlocking {
             requestIgnoringResponseException {
-                apiService.deletePhoneNumberById("phone_number_id")
+                apiService.deletePhoneNumberById(id = "phone_number_id")
             }.verifyDelete("/users/phone_numbers/phone_number_id")
         }
     }
@@ -407,7 +407,7 @@ internal class StytchApiServiceTests {
     fun `check deleteBiometricRegistrationById request`() {
         runBlocking {
             requestIgnoringResponseException {
-                apiService.deleteBiometricRegistrationById("biometrics_registration_id")
+                apiService.deleteBiometricRegistrationById(id = "biometrics_registration_id")
             }.verifyDelete("/users/biometric_registrations/biometrics_registration_id")
         }
     }
@@ -416,7 +416,7 @@ internal class StytchApiServiceTests {
     fun `check deleteCryptoWalletById request`() {
         runBlocking {
             requestIgnoringResponseException {
-                apiService.deleteCryptoWalletById("crypto_wallet_id")
+                apiService.deleteCryptoWalletById(id = "crypto_wallet_id")
             }.verifyDelete("/users/crypto_wallets/crypto_wallet_id")
         }
     }
@@ -425,7 +425,7 @@ internal class StytchApiServiceTests {
     fun `check deleteWebAuthnById request`() {
         runBlocking {
             requestIgnoringResponseException {
-                apiService.deleteWebAuthnById("webauthn_registration_id")
+                apiService.deleteWebAuthnById(id = "webauthn_registration_id")
             }.verifyDelete("/users/webauthn_registrations/webauthn_registration_id")
         }
     }

--- a/sdk/src/test/java/com/stytch/sdk/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/network/StytchApiServiceTests.kt
@@ -6,6 +6,7 @@ import com.stytch.sdk.utils.verifyPost
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okio.EOFException
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -36,23 +37,22 @@ internal class StytchApiServiceTests {
     @Test
     fun `check magic links email loginOrCreate request`() {
         runBlocking {
-            val request = StytchRequests.MagicLinks.Email.LoginOrCreateUserRequest(
+            val parameters = StytchRequests.MagicLinks.Email.LoginOrCreateUserRequest(
                 EMAIL,
                 LOGIN_MAGIC_LINK,
                 "123",
                 "method2"
             )
-            try {
-                apiService.loginOrCreateUserByEmail(request)
-            } catch (_: Exception) {
+            requestIgnoringResponseException {
+                apiService.loginOrCreateUserByEmail(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/magic_links/email/login_or_create",
                 expectedBody = mapOf(
-                    "email" to request.email,
-                    "login_magic_link_url" to request.loginMagicLinkUrl,
-                    "code_challenge" to request.codeChallenge,
-                    "code_challenge_method" to request.codeChallengeMethod
+                    "email" to parameters.email,
+                    "login_magic_link_url" to parameters.loginMagicLinkUrl,
+                    "code_challenge" to parameters.codeChallenge,
+                    "code_challenge_method" to parameters.codeChallengeMethod
                 )
             )
         }
@@ -61,21 +61,20 @@ internal class StytchApiServiceTests {
     @Test
     fun `check magic links authenticate request`() {
         runBlocking {
-            val request = StytchRequests.MagicLinks.AuthenticateRequest(
+            val parameters = StytchRequests.MagicLinks.AuthenticateRequest(
                 "token",
                 "123",
                 60
             )
-            try {
-                apiService.authenticate(request)
-            } catch (_: Exception) {
+            requestIgnoringResponseException {
+                apiService.authenticate(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/magic_links/authenticate",
                 expectedBody = mapOf(
-                    "token" to request.token,
-                    "session_duration_minutes" to request.sessionDurationMinutes,
-                    "code_verifier" to request.codeVerifier,
+                    "token" to parameters.token,
+                    "session_duration_minutes" to parameters.sessionDurationMinutes,
+                    "code_verifier" to parameters.codeVerifier,
                 )
             )
         }
@@ -87,19 +86,18 @@ internal class StytchApiServiceTests {
     @Test
     fun `check OTP email loginOrCreate with default expiration request`() {
         runBlocking {
-            val request = StytchRequests.OTP.Email(
+            val parameters = StytchRequests.OTP.Email(
                 EMAIL,
                 60
             )
-            try {
-                apiService.loginOrCreateUserByOTPWithEmail(request)
-            } catch (_: Exception) {
+            requestIgnoringResponseException {
+                apiService.loginOrCreateUserByOTPWithEmail(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/otps/email/login_or_create",
                 expectedBody = mapOf(
-                    "email" to request.email,
-                    "expiration_minutes" to request.expirationMinutes
+                    "email" to parameters.email,
+                    "expiration_minutes" to parameters.expirationMinutes
                 )
             )
         }
@@ -108,19 +106,18 @@ internal class StytchApiServiceTests {
     @Test
     fun `check OTP sms loginOrCreate request`() {
         runBlocking {
-            val request = StytchRequests.OTP.SMS(
+            val parameters = StytchRequests.OTP.SMS(
                 "000",
                 24
             )
-            try {
-                apiService.loginOrCreateUserByOTPWithSMS(request)
-            } catch (_: Exception) {
+            requestIgnoringResponseException {
+                apiService.loginOrCreateUserByOTPWithSMS(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/otps/sms/login_or_create",
                 expectedBody = mapOf(
-                    "phone_number" to request.phoneNumber,
-                    "expiration_minutes" to request.expirationMinutes
+                    "phone_number" to parameters.phoneNumber,
+                    "expiration_minutes" to parameters.expirationMinutes
                 )
             )
         }
@@ -129,19 +126,18 @@ internal class StytchApiServiceTests {
     @Test
     fun `check OTP whatsapp loginOrCreate with default expiration request`() {
         runBlocking {
-            val request = StytchRequests.OTP.WhatsApp(
+            val parameters = StytchRequests.OTP.WhatsApp(
                 "000",
                 60
             )
-            try {
-                apiService.loginOrCreateUserByOTPWithWhatsApp(request)
-            } catch (_: Exception) {
+            requestIgnoringResponseException {
+                apiService.loginOrCreateUserByOTPWithWhatsApp(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/otps/whatsapp/login_or_create",
                 expectedBody = mapOf(
-                    "phone_number" to request.phoneNumber,
-                    "expiration_minutes" to request.expirationMinutes
+                    "phone_number" to parameters.phoneNumber,
+                    "expiration_minutes" to parameters.expirationMinutes
                 )
             )
         }
@@ -150,21 +146,20 @@ internal class StytchApiServiceTests {
     @Test
     fun `check OTP authenticate request`() {
         runBlocking {
-            val request = StytchRequests.OTP.Authenticate(
+            val parameters = StytchRequests.OTP.Authenticate(
                 "token",
                 "methodId",
                 60
             )
-            try {
-                apiService.authenticateWithOTP(request)
-            } catch (_: Exception) {
+            requestIgnoringResponseException {
+                apiService.authenticateWithOTP(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/otps/authenticate",
                 expectedBody = mapOf(
-                    "token" to request.token,
-                    "method_id" to request.methodId,
-                    "session_duration_minutes" to request.sessionDurationMinutes,
+                    "token" to parameters.token,
+                    "method_id" to parameters.methodId,
+                    "session_duration_minutes" to parameters.sessionDurationMinutes,
                 )
             )
         }
@@ -177,21 +172,20 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Passwords create request`() {
         runBlocking {
-            val request = StytchRequests.Passwords.CreateRequest(
+            val parameters = StytchRequests.Passwords.CreateRequest(
                 EMAIL,
                 "123asd",
                 60
             )
-            try {
-                apiService.passwords(request)
-            } catch (_: Exception) {
+            requestIgnoringResponseException {
+                apiService.passwords(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/passwords",
                 expectedBody = mapOf(
-                    "email" to request.email,
-                    "password" to request.password,
-                    "session_duration_minutes" to request.sessionDurationMinutes
+                    "email" to parameters.email,
+                    "password" to parameters.password,
+                    "session_duration_minutes" to parameters.sessionDurationMinutes
                 )
             )
         }
@@ -200,19 +194,18 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Passwords strenghtCheck request`() {
         runBlocking {
-            val request = StytchRequests.Passwords.StrengthCheckRequest(
+            val parameters = StytchRequests.Passwords.StrengthCheckRequest(
                 EMAIL,
                 "123asd"
             )
-            try {
-                apiService.strengthCheck(request)
-            } catch (_: Exception) {
+            requestIgnoringResponseException {
+                apiService.strengthCheck(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/passwords/strength_check",
                 expectedBody = mapOf(
-                    "email" to request.email,
-                    "password" to request.password
+                    "email" to parameters.email,
+                    "password" to parameters.password
                 )
             )
         }
@@ -221,23 +214,22 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Passwords resetbyEmail request`() {
         runBlocking {
-            val request = StytchRequests.Passwords.ResetByEmailRequest(
+            val parameters = StytchRequests.Passwords.ResetByEmailRequest(
                 "token",
                 "123asd",
                 60,
                 "ver1"
             )
-            try {
-                apiService.resetByEmail(request)
-            } catch (_: Exception) {
+            requestIgnoringResponseException {
+                apiService.resetByEmail(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/passwords/email/reset",
                 expectedBody = mapOf(
-                    "token" to request.token,
-                    "password" to request.password,
-                    "session_duration_minutes" to request.sessionDurationMinutes,
-                    "code_verifier" to request.codeVerifier
+                    "token" to parameters.token,
+                    "password" to parameters.password,
+                    "session_duration_minutes" to parameters.sessionDurationMinutes,
+                    "code_verifier" to parameters.codeVerifier
                 )
             )
         }
@@ -246,7 +238,7 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Passwords resetbyEmailStart request`() {
         runBlocking {
-            val request = StytchRequests.Passwords.ResetByEmailStartRequest(
+            val parameters = StytchRequests.Passwords.ResetByEmailStartRequest(
                 EMAIL,
                 "123",
                 "method2",
@@ -255,20 +247,19 @@ internal class StytchApiServiceTests {
                 "resetPasswordUrl",
                 23
             )
-            try {
-                apiService.resetByEmailStart(request)
-            } catch (_: Exception) {
+            requestIgnoringResponseException {
+                apiService.resetByEmailStart(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/passwords/email/reset/start",
                 expectedBody = mapOf(
-                    "email" to request.email,
-                    "code_challenge" to request.codeChallenge,
-                    "code_challenge_method" to request.codeChallengeMethod,
-                    "login_redirect_url" to request.loginRedirectUrl,
-                    "reset_password_redirect_url" to request.resetPasswordRedirectUrl,
-                    "login_expiration_minutes" to request.loginExpirationMinutes,
-                    "reset_password_expiration_minutes" to request.resetPasswordExpirationMinutes
+                    "email" to parameters.email,
+                    "code_challenge" to parameters.codeChallenge,
+                    "code_challenge_method" to parameters.codeChallengeMethod,
+                    "login_redirect_url" to parameters.loginRedirectUrl,
+                    "reset_password_redirect_url" to parameters.resetPasswordRedirectUrl,
+                    "login_expiration_minutes" to parameters.loginExpirationMinutes,
+                    "reset_password_expiration_minutes" to parameters.resetPasswordExpirationMinutes
                 )
             )
         }
@@ -277,21 +268,20 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Passwords authenticate request`() {
         runBlocking {
-            val request = StytchRequests.Passwords.AuthenticateRequest(
+            val parameters = StytchRequests.Passwords.AuthenticateRequest(
                 EMAIL,
                 "123asd",
                 46
             )
-            try {
-                apiService.authenticateWithPasswords(request)
-            } catch (_: Exception) {
+            requestIgnoringResponseException {
+                apiService.authenticateWithPasswords(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/passwords/authenticate",
                 expectedBody = mapOf(
-                    "email" to request.email,
-                    "password" to request.password,
-                    "session_duration_minutes" to request.sessionDurationMinutes
+                    "email" to parameters.email,
+                    "password" to parameters.password,
+                    "session_duration_minutes" to parameters.sessionDurationMinutes
                 )
             )
         }
@@ -304,14 +294,13 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Sessions authenticate request`() {
         runBlocking {
-            val request = StytchRequests.Sessions.AuthenticateRequest(24)
-            try {
-                apiService.authenticateSessions(request)
-            } catch (_: Exception) {
+            val parameters = StytchRequests.Sessions.AuthenticateRequest(24)
+            requestIgnoringResponseException {
+                apiService.authenticateSessions(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/sessions/authenticate",
-                expectedBody = mapOf("session_duration_minutes" to request.sessionDurationMinutes)
+                expectedBody = mapOf("session_duration_minutes" to parameters.sessionDurationMinutes)
             )
         }
     }
@@ -319,9 +308,8 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Sessions revoke request`() {
         runBlocking {
-            try {
+            requestIgnoringResponseException {
                 apiService.revokeSessions()
-            } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(expectedPath = "/sessions/revoke")
         }
@@ -333,13 +321,13 @@ internal class StytchApiServiceTests {
     @Test
     fun `check biometricsRegisterStart request`() {
         runBlocking {
-            val request = StytchRequests.Biometrics.RegisterStartRequest(publicKey = "publicKey")
-            try {
-                apiService.biometricsRegisterStart(request)
-            } catch (_: Exception) {}
+            val parameters = StytchRequests.Biometrics.RegisterStartRequest(publicKey = "publicKey")
+            requestIgnoringResponseException {
+                apiService.biometricsRegisterStart(parameters)
+            }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/biometrics/register/start",
-                expectedBody = mapOf("public_key" to request.publicKey)
+                expectedBody = mapOf("public_key" to parameters.publicKey)
             )
         }
     }
@@ -347,20 +335,20 @@ internal class StytchApiServiceTests {
     @Test
     fun `check biometricsRegister request`() {
         runBlocking {
-            val request = StytchRequests.Biometrics.RegisterRequest(
+            val parameters = StytchRequests.Biometrics.RegisterRequest(
                 signature = "signature",
                 biometricRegistrationId = "biometricRegistrationId",
                 sessionDurationMinutes = 30
             )
-            try {
-                apiService.biometricsRegister(request)
-            } catch (_: Exception) {}
+            requestIgnoringResponseException {
+                apiService.biometricsRegister(parameters)
+            }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/biometrics/register",
                 expectedBody = mapOf(
-                    "signature" to request.signature,
-                    "biometric_registration_id" to request.biometricRegistrationId,
-                    "session_duration_minutes" to request.sessionDurationMinutes
+                    "signature" to parameters.signature,
+                    "biometric_registration_id" to parameters.biometricRegistrationId,
+                    "session_duration_minutes" to parameters.sessionDurationMinutes
                 )
             )
         }
@@ -369,13 +357,13 @@ internal class StytchApiServiceTests {
     @Test
     fun `check biometricsAuthenticateStart request`() {
         runBlocking {
-            val request = StytchRequests.Biometrics.AuthenticateStartRequest(publicKey = "publicKey")
-            try {
-                apiService.biometricsAuthenticateStart(request)
-            } catch (_: Exception) {}
+            val parameters = StytchRequests.Biometrics.AuthenticateStartRequest(publicKey = "publicKey")
+            requestIgnoringResponseException {
+                apiService.biometricsAuthenticateStart(parameters)
+            }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/biometrics/authenticate/start",
-                expectedBody = mapOf("public_key" to request.publicKey)
+                expectedBody = mapOf("public_key" to parameters.publicKey)
             )
         }
     }
@@ -383,20 +371,20 @@ internal class StytchApiServiceTests {
     @Test
     fun `check biometricsAuthenticate request`() {
         runBlocking {
-            val request = StytchRequests.Biometrics.AuthenticateRequest(
+            val parameters = StytchRequests.Biometrics.AuthenticateRequest(
                 signature = "signature",
                 biometricRegistrationId = "biometricRegistrationId",
                 sessionDurationMinutes = 30
             )
-            try {
-                apiService.biometricsAuthenticate(request)
-            } catch (_: Exception) {}
+            requestIgnoringResponseException {
+                apiService.biometricsAuthenticate(parameters)
+            }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/biometrics/authenticate",
                 expectedBody = mapOf(
-                    "signature" to request.signature,
-                    "biometric_registration_id" to request.biometricRegistrationId,
-                    "session_duration_minutes" to request.sessionDurationMinutes
+                    "signature" to parameters.signature,
+                    "biometric_registration_id" to parameters.biometricRegistrationId,
+                    "session_duration_minutes" to parameters.sessionDurationMinutes
                 )
             )
         }
@@ -407,9 +395,8 @@ internal class StytchApiServiceTests {
     @Test
     fun `check getUser request`() {
         runBlocking {
-            try {
+            requestIgnoringResponseException {
                 apiService.getUser()
-            } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyGet("/users/me")
         }
@@ -418,9 +405,8 @@ internal class StytchApiServiceTests {
     @Test
     fun `check deleteEmailById request`() {
         runBlocking {
-            try {
+            requestIgnoringResponseException {
                 apiService.deleteEmailById("email_id")
-            } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyDelete("/users/emails/email_id")
         }
@@ -429,9 +415,8 @@ internal class StytchApiServiceTests {
     @Test
     fun `check deletePhoneNumberById request`() {
         runBlocking {
-            try {
+            requestIgnoringResponseException {
                 apiService.deletePhoneNumberById("phone_number_id")
-            } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyDelete("/users/phone_numbers/phone_number_id")
         }
@@ -440,9 +425,8 @@ internal class StytchApiServiceTests {
     @Test
     fun `check deleteBiometricRegistrationById request`() {
         runBlocking {
-            try {
+            requestIgnoringResponseException {
                 apiService.deleteBiometricRegistrationById("biometrics_registration_id")
-            } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyDelete("/users/biometric_registrations/biometrics_registration_id")
         }
@@ -451,9 +435,8 @@ internal class StytchApiServiceTests {
     @Test
     fun `check deleteCryptoWalletById request`() {
         runBlocking {
-            try {
+            requestIgnoringResponseException {
                 apiService.deleteCryptoWalletById("crypto_wallet_id")
-            } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyDelete("/users/crypto_wallets/crypto_wallet_id")
         }
@@ -462,9 +445,8 @@ internal class StytchApiServiceTests {
     @Test
     fun `check deleteWebAuthnById request`() {
         runBlocking {
-            try {
+            requestIgnoringResponseException {
                 apiService.deleteWebAuthnById("webauthn_registration_id")
-            } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyDelete("/users/webauthn_registrations/webauthn_registration_id")
         }
@@ -475,21 +457,20 @@ internal class StytchApiServiceTests {
     @Test
     fun `check authenticateWithGoogleIdToken request`() {
         runBlocking {
-            val request = StytchRequests.OAuth.Google.AuthenticateRequest(
+            val parameters = StytchRequests.OAuth.Google.AuthenticateRequest(
                 idToken = "id_token",
                 nonce = "nonce",
                 sessionDurationMinutes = 30
             )
-            try {
-                apiService.authenticateWithGoogleIdToken(request)
-            } catch (_: Exception) {
+            requestIgnoringResponseException {
+                apiService.authenticateWithGoogleIdToken(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/oauth/google/id_token/authenticate",
                 expectedBody = mapOf(
-                    "id_token" to request.idToken,
-                    "nonce" to request.nonce,
-                    "session_duration_minutes" to request.sessionDurationMinutes
+                    "id_token" to parameters.idToken,
+                    "nonce" to parameters.nonce,
+                    "session_duration_minutes" to parameters.sessionDurationMinutes
                 )
             )
         }
@@ -498,24 +479,29 @@ internal class StytchApiServiceTests {
     @Test
     fun `check authenticateWithThirdPartyToken request`() {
         runBlocking {
-            val request = StytchRequests.OAuth.ThirdParty.AuthenticateRequest(
+            val parameters = StytchRequests.OAuth.ThirdParty.AuthenticateRequest(
                 token = "id_token",
                 sessionDurationMinutes = 30,
                 codeVerifier = "code_challenge"
             )
-            try {
-                apiService.authenticateWithThirdPartyToken(request)
-            } catch (_: Exception) {
+            requestIgnoringResponseException {
+                apiService.authenticateWithThirdPartyToken(parameters)
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/oauth/authenticate",
                 expectedBody = mapOf(
-                    "token" to request.token,
-                    "session_duration_minutes" to request.sessionDurationMinutes,
-                    "code_verifier" to request.codeVerifier
+                    "token" to parameters.token,
+                    "session_duration_minutes" to parameters.sessionDurationMinutes,
+                    "code_verifier" to parameters.codeVerifier
                 )
             )
         }
     }
     // endregion OAuth
+
+    private suspend fun requestIgnoringResponseException(block: suspend () -> Unit) = try {
+        block()
+    } catch (_: EOFException) {
+        // OkHTTP throws EOFException because it expects a response body, but we're intentionally not creating them
+    }
 }

--- a/sdk/src/test/java/com/stytch/sdk/network/StytchApiServiceTests.kt
+++ b/sdk/src/test/java/com/stytch/sdk/network/StytchApiServiceTests.kt
@@ -36,24 +36,23 @@ internal class StytchApiServiceTests {
     @Test
     fun `check magic links email loginOrCreate request`() {
         runBlocking {
+            val request = StytchRequests.MagicLinks.Email.LoginOrCreateUserRequest(
+                EMAIL,
+                LOGIN_MAGIC_LINK,
+                "123",
+                "method2"
+            )
             try {
-                apiService.loginOrCreateUserByEmail(
-                    StytchRequests.MagicLinks.Email.LoginOrCreateUserRequest(
-                        EMAIL,
-                        LOGIN_MAGIC_LINK,
-                        "123",
-                        "method2"
-                    )
-                )
+                apiService.loginOrCreateUserByEmail(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/magic_links/email/login_or_create",
                 expectedBody = mapOf(
-                    "email" to EMAIL,
-                    "login_magic_link_url" to LOGIN_MAGIC_LINK,
-                    "code_challenge" to "123",
-                    "code_challenge_method" to "method2"
+                    "email" to request.email,
+                    "login_magic_link_url" to request.loginMagicLinkUrl,
+                    "code_challenge" to request.codeChallenge,
+                    "code_challenge_method" to request.codeChallengeMethod
                 )
             )
         }
@@ -62,21 +61,21 @@ internal class StytchApiServiceTests {
     @Test
     fun `check magic links authenticate request`() {
         runBlocking {
+            val request = StytchRequests.MagicLinks.AuthenticateRequest(
+                "token",
+                "123",
+                60
+            )
             try {
-                apiService.authenticate(
-                    StytchRequests.MagicLinks.AuthenticateRequest(
-                        "token",
-                        "123",
-                        60
-                    )
-                )
+                apiService.authenticate(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/magic_links/authenticate",
                 expectedBody = mapOf(
-                    "token" to "token",
-                    "session_duration_minutes" to 60
+                    "token" to request.token,
+                    "session_duration_minutes" to request.sessionDurationMinutes,
+                    "code_verifier" to request.codeVerifier,
                 )
             )
         }
@@ -88,20 +87,19 @@ internal class StytchApiServiceTests {
     @Test
     fun `check OTP email loginOrCreate with default expiration request`() {
         runBlocking {
+            val request = StytchRequests.OTP.Email(
+                EMAIL,
+                60
+            )
             try {
-                apiService.loginOrCreateUserByOTPWithEmail(
-                    StytchRequests.OTP.Email(
-                        EMAIL,
-                        60
-                    )
-                )
+                apiService.loginOrCreateUserByOTPWithEmail(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/otps/email/login_or_create",
                 expectedBody = mapOf(
-                    "email" to EMAIL,
-                    "expiration_minutes" to 60
+                    "email" to request.email,
+                    "expiration_minutes" to request.expirationMinutes
                 )
             )
         }
@@ -110,20 +108,19 @@ internal class StytchApiServiceTests {
     @Test
     fun `check OTP sms loginOrCreate request`() {
         runBlocking {
+            val request = StytchRequests.OTP.SMS(
+                "000",
+                24
+            )
             try {
-                apiService.loginOrCreateUserByOTPWithSMS(
-                    StytchRequests.OTP.SMS(
-                        "000",
-                        24
-                    )
-                )
+                apiService.loginOrCreateUserByOTPWithSMS(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/otps/sms/login_or_create",
                 expectedBody = mapOf(
-                    "phone_number" to "000",
-                    "expiration_minutes" to 24
+                    "phone_number" to request.phoneNumber,
+                    "expiration_minutes" to request.expirationMinutes
                 )
             )
         }
@@ -132,20 +129,19 @@ internal class StytchApiServiceTests {
     @Test
     fun `check OTP whatsapp loginOrCreate with default expiration request`() {
         runBlocking {
+            val request = StytchRequests.OTP.WhatsApp(
+                "000",
+                60
+            )
             try {
-                apiService.loginOrCreateUserByOTPWithWhatsApp(
-                    StytchRequests.OTP.WhatsApp(
-                        "000",
-                        60
-                    )
-                )
+                apiService.loginOrCreateUserByOTPWithWhatsApp(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/otps/whatsapp/login_or_create",
                 expectedBody = mapOf(
-                    "phone_number" to "000",
-                    "expiration_minutes" to 60
+                    "phone_number" to request.phoneNumber,
+                    "expiration_minutes" to request.expirationMinutes
                 )
             )
         }
@@ -154,22 +150,21 @@ internal class StytchApiServiceTests {
     @Test
     fun `check OTP authenticate request`() {
         runBlocking {
+            val request = StytchRequests.OTP.Authenticate(
+                "token",
+                "methodId",
+                60
+            )
             try {
-                apiService.authenticateWithOTP(
-                    StytchRequests.OTP.Authenticate(
-                        "token",
-                        "methodId",
-                        60
-                    )
-                )
+                apiService.authenticateWithOTP(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/otps/authenticate",
                 expectedBody = mapOf(
-                    "token" to "token",
-                    "method_id" to "methodId",
-                    "session_duration_minutes" to 60
+                    "token" to request.token,
+                    "method_id" to request.methodId,
+                    "session_duration_minutes" to request.sessionDurationMinutes,
                 )
             )
         }
@@ -182,22 +177,21 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Passwords create request`() {
         runBlocking {
+            val request = StytchRequests.Passwords.CreateRequest(
+                EMAIL,
+                "123asd",
+                60
+            )
             try {
-                apiService.passwords(
-                    StytchRequests.Passwords.CreateRequest(
-                        EMAIL,
-                        "123asd",
-                        60
-                    )
-                )
+                apiService.passwords(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/passwords",
                 expectedBody = mapOf(
-                    "email" to EMAIL,
-                    "password" to "123asd",
-                    "session_duration_minutes" to 60
+                    "email" to request.email,
+                    "password" to request.password,
+                    "session_duration_minutes" to request.sessionDurationMinutes
                 )
             )
         }
@@ -206,20 +200,19 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Passwords strenghtCheck request`() {
         runBlocking {
+            val request = StytchRequests.Passwords.StrengthCheckRequest(
+                EMAIL,
+                "123asd"
+            )
             try {
-                apiService.strengthCheck(
-                    StytchRequests.Passwords.StrengthCheckRequest(
-                        EMAIL,
-                        "123asd"
-                    )
-                )
+                apiService.strengthCheck(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/passwords/strength_check",
                 expectedBody = mapOf(
-                    "email" to EMAIL,
-                    "password" to "123asd"
+                    "email" to request.email,
+                    "password" to request.password
                 )
             )
         }
@@ -228,24 +221,23 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Passwords resetbyEmail request`() {
         runBlocking {
+            val request = StytchRequests.Passwords.ResetByEmailRequest(
+                "token",
+                "123asd",
+                60,
+                "ver1"
+            )
             try {
-                apiService.resetByEmail(
-                    StytchRequests.Passwords.ResetByEmailRequest(
-                        "token",
-                        "123asd",
-                        60,
-                        "ver1"
-                    )
-                )
+                apiService.resetByEmail(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/passwords/email/reset",
                 expectedBody = mapOf(
-                    "token" to "token",
-                    "password" to "123asd",
-                    "session_duration_minutes" to 60,
-                    "code_verifier" to "ver1"
+                    "token" to request.token,
+                    "password" to request.password,
+                    "session_duration_minutes" to request.sessionDurationMinutes,
+                    "code_verifier" to request.codeVerifier
                 )
             )
         }
@@ -254,30 +246,29 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Passwords resetbyEmailStart request`() {
         runBlocking {
+            val request = StytchRequests.Passwords.ResetByEmailStartRequest(
+                EMAIL,
+                "123",
+                "method2",
+                "loginRedirect",
+                24,
+                "resetPasswordUrl",
+                23
+            )
             try {
-                apiService.resetByEmailStart(
-                    StytchRequests.Passwords.ResetByEmailStartRequest(
-                        EMAIL,
-                        "123",
-                        "method2",
-                        "loginRedirect",
-                        24,
-                        "resetPasswordUrl",
-                        23
-                    )
-                )
+                apiService.resetByEmailStart(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/passwords/email/reset/start",
                 expectedBody = mapOf(
-                    "email" to EMAIL,
-                    "code_challenge" to "123",
-                    "code_challenge_method" to "method2",
-                    "login_redirect_url" to "loginRedirect",
-                    "reset_password_redirect_url" to "resetPasswordUrl",
-                    "login_expiration_minutes" to 24,
-                    "reset_password_expiration_minutes" to 23
+                    "email" to request.email,
+                    "code_challenge" to request.codeChallenge,
+                    "code_challenge_method" to request.codeChallengeMethod,
+                    "login_redirect_url" to request.loginRedirectUrl,
+                    "reset_password_redirect_url" to request.resetPasswordRedirectUrl,
+                    "login_expiration_minutes" to request.loginExpirationMinutes,
+                    "reset_password_expiration_minutes" to request.resetPasswordExpirationMinutes
                 )
             )
         }
@@ -286,22 +277,21 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Passwords authenticate request`() {
         runBlocking {
+            val request = StytchRequests.Passwords.AuthenticateRequest(
+                EMAIL,
+                "123asd",
+                46
+            )
             try {
-                apiService.authenticateWithPasswords(
-                    StytchRequests.Passwords.AuthenticateRequest(
-                        EMAIL,
-                        "123asd",
-                        46
-                    )
-                )
+                apiService.authenticateWithPasswords(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/passwords/authenticate",
                 expectedBody = mapOf(
-                    "email" to EMAIL,
-                    "password" to "123asd",
-                    "session_duration_minutes" to 46
+                    "email" to request.email,
+                    "password" to request.password,
+                    "session_duration_minutes" to request.sessionDurationMinutes
                 )
             )
         }
@@ -314,19 +304,14 @@ internal class StytchApiServiceTests {
     @Test
     fun `check Sessions authenticate request`() {
         runBlocking {
+            val request = StytchRequests.Sessions.AuthenticateRequest(24)
             try {
-                apiService.authenticateSessions(
-                    StytchRequests.Sessions.AuthenticateRequest(
-                        24
-                    )
-                )
+                apiService.authenticateSessions(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/sessions/authenticate",
-                expectedBody = mapOf(
-                    "session_duration_minutes" to 24
-                )
+                expectedBody = mapOf("session_duration_minutes" to request.sessionDurationMinutes)
             )
         }
     }
@@ -338,9 +323,7 @@ internal class StytchApiServiceTests {
                 apiService.revokeSessions()
             } catch (_: Exception) {
             }
-            mockWebServer.takeRequest().verifyPost(
-                expectedPath = "/sessions/revoke"
-            )
+            mockWebServer.takeRequest().verifyPost(expectedPath = "/sessions/revoke")
         }
     }
 
@@ -350,16 +333,13 @@ internal class StytchApiServiceTests {
     @Test
     fun `check biometricsRegisterStart request`() {
         runBlocking {
+            val request = StytchRequests.Biometrics.RegisterStartRequest(publicKey = "publicKey")
             try {
-                apiService.biometricsRegisterStart(
-                    StytchRequests.Biometrics.RegisterStartRequest(publicKey = "publicKey")
-                )
+                apiService.biometricsRegisterStart(request)
             } catch (_: Exception) {}
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/biometrics/register/start",
-                expectedBody = mapOf(
-                    "public_key" to "publicKey"
-                )
+                expectedBody = mapOf("public_key" to request.publicKey)
             )
         }
     }
@@ -367,21 +347,20 @@ internal class StytchApiServiceTests {
     @Test
     fun `check biometricsRegister request`() {
         runBlocking {
+            val request = StytchRequests.Biometrics.RegisterRequest(
+                signature = "signature",
+                biometricRegistrationId = "biometricRegistrationId",
+                sessionDurationMinutes = 30
+            )
             try {
-                apiService.biometricsRegister(
-                    StytchRequests.Biometrics.RegisterRequest(
-                        signature = "signature",
-                        biometricRegistrationId = "biometricRegistrationId",
-                        sessionDurationMinutes = 30
-                    )
-                )
+                apiService.biometricsRegister(request)
             } catch (_: Exception) {}
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/biometrics/register",
                 expectedBody = mapOf(
-                    "signature" to "signature",
-                    "biometric_registration_id" to "biometricRegistrationId",
-                    "session_duration_minutes" to 30
+                    "signature" to request.signature,
+                    "biometric_registration_id" to request.biometricRegistrationId,
+                    "session_duration_minutes" to request.sessionDurationMinutes
                 )
             )
         }
@@ -390,16 +369,13 @@ internal class StytchApiServiceTests {
     @Test
     fun `check biometricsAuthenticateStart request`() {
         runBlocking {
+            val request = StytchRequests.Biometrics.AuthenticateStartRequest(publicKey = "publicKey")
             try {
-                apiService.biometricsAuthenticateStart(
-                    StytchRequests.Biometrics.AuthenticateStartRequest(publicKey = "publicKey")
-                )
+                apiService.biometricsAuthenticateStart(request)
             } catch (_: Exception) {}
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/biometrics/authenticate/start",
-                expectedBody = mapOf(
-                    "public_key" to "publicKey"
-                )
+                expectedBody = mapOf("public_key" to request.publicKey)
             )
         }
     }
@@ -407,21 +383,20 @@ internal class StytchApiServiceTests {
     @Test
     fun `check biometricsAuthenticate request`() {
         runBlocking {
+            val request = StytchRequests.Biometrics.AuthenticateRequest(
+                signature = "signature",
+                biometricRegistrationId = "biometricRegistrationId",
+                sessionDurationMinutes = 30
+            )
             try {
-                apiService.biometricsAuthenticate(
-                    StytchRequests.Biometrics.AuthenticateRequest(
-                        signature = "signature",
-                        biometricRegistrationId = "biometricRegistrationId",
-                        sessionDurationMinutes = 30
-                    )
-                )
+                apiService.biometricsAuthenticate(request)
             } catch (_: Exception) {}
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/biometrics/authenticate",
                 expectedBody = mapOf(
-                    "signature" to "signature",
-                    "biometric_registration_id" to "biometricRegistrationId",
-                    "session_duration_minutes" to 30
+                    "signature" to request.signature,
+                    "biometric_registration_id" to request.biometricRegistrationId,
+                    "session_duration_minutes" to request.sessionDurationMinutes
                 )
             )
         }
@@ -500,22 +475,21 @@ internal class StytchApiServiceTests {
     @Test
     fun `check authenticateWithGoogleIdToken request`() {
         runBlocking {
+            val request = StytchRequests.OAuth.Google.AuthenticateRequest(
+                idToken = "id_token",
+                nonce = "nonce",
+                sessionDurationMinutes = 30
+            )
             try {
-                apiService.authenticateWithGoogleIdToken(
-                    StytchRequests.OAuth.Google.AuthenticateRequest(
-                        idToken = "id_token",
-                        nonce = "nonce",
-                        sessionDurationMinutes = 30
-                    )
-                )
+                apiService.authenticateWithGoogleIdToken(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/oauth/google/id_token/authenticate",
                 expectedBody = mapOf(
-                    "id_token" to "id_token",
-                    "nonce" to "nonce",
-                    "session_duration_minutes" to 30
+                    "id_token" to request.idToken,
+                    "nonce" to request.nonce,
+                    "session_duration_minutes" to request.sessionDurationMinutes
                 )
             )
         }
@@ -524,22 +498,21 @@ internal class StytchApiServiceTests {
     @Test
     fun `check authenticateWithThirdPartyToken request`() {
         runBlocking {
+            val request = StytchRequests.OAuth.ThirdParty.AuthenticateRequest(
+                token = "id_token",
+                sessionDurationMinutes = 30,
+                codeVerifier = "code_challenge"
+            )
             try {
-                apiService.authenticateWithThirdPartyToken(
-                    StytchRequests.OAuth.ThirdParty.AuthenticateRequest(
-                        token = "id_token",
-                        sessionDurationMinutes = 30,
-                        codeVerifier = "code_challenge"
-                    )
-                )
+                apiService.authenticateWithThirdPartyToken(request)
             } catch (_: Exception) {
             }
             mockWebServer.takeRequest().verifyPost(
                 expectedPath = "/oauth/authenticate",
                 expectedBody = mapOf(
-                    "token" to "id_token",
-                    "session_duration_minutes" to 30,
-                    "code_verifier" to "code_challenge"
+                    "token" to request.token,
+                    "session_duration_minutes" to request.sessionDurationMinutes,
+                    "code_verifier" to request.codeVerifier
                 )
             )
         }

--- a/sdk/src/test/java/com/stytch/sdk/utils/RecordedRequestExtensions.kt
+++ b/sdk/src/test/java/com/stytch/sdk/utils/RecordedRequestExtensions.kt
@@ -7,7 +7,7 @@ import org.junit.Assert.fail
 private fun RecordedRequest.verify(
     expectedMethod: String,
     expectedPath: String,
-    expectedBody: Map<String, Any>,
+    expectedBody: Map<String, Any?>,
 ) {
     assert(method == expectedMethod)
     assert(path == expectedPath)
@@ -31,7 +31,7 @@ private fun RecordedRequest.verify(
 
 internal fun RecordedRequest.verifyPost(
     expectedPath: String,
-    expectedBody: Map<String, Any> = emptyMap()
+    expectedBody: Map<String, Any?> = emptyMap()
 ) = verify("POST", expectedPath, expectedBody)
 
 internal fun RecordedRequest.verifyGet(

--- a/sdk/src/test/java/com/stytch/sdk/utils/RecordedRequestExtensions.kt
+++ b/sdk/src/test/java/com/stytch/sdk/utils/RecordedRequestExtensions.kt
@@ -1,8 +1,34 @@
 package com.stytch.sdk.utils
 
+import com.google.gson.JsonElement
 import com.google.gson.JsonParser
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Assert.fail
+
+private fun compare(key: String, requestValue: JsonElement, expectedValue: Any?) {
+    require(expectedValue != null) {
+        "Request contained a value for $key but expected was null"
+    }
+    if (requestValue.isJsonObject) {
+        // objects should be deep-compared
+        val nestedObject = requestValue.asJsonObject
+        require(expectedValue is Map<*, *>) {
+            "Request contains an object with keys ${nestedObject.keySet()} but expected $expectedValue"
+        }
+        require(nestedObject.size() == expectedValue.size) {
+            "Request contains different keys (${nestedObject.keySet()}) than expected (${expectedValue.keys})"
+        }
+        nestedObject.keySet().forEach { nestedKey ->
+            val nestedRequestValue = nestedObject.get(nestedKey)
+            compare(nestedKey, nestedRequestValue, expectedValue[nestedKey])
+        }
+    } else {
+        // primitives and arrays can be string compared
+        require(requestValue.asString == expectedValue.toString()) {
+            "Expected $expectedValue but got $requestValue"
+        }
+    }
+}
 
 private fun RecordedRequest.verify(
     expectedMethod: String,
@@ -16,16 +42,21 @@ private fun RecordedRequest.verify(
         bodyString = "{}"
     }
     val bodyJson = JsonParser.parseString(bodyString).asJsonObject
-    expectedBody.forEach { (key, value) ->
+    expectedBody.forEach { (key, expectedValue) ->
+        val requestValue = bodyJson.get(key)
         try {
-            assert(bodyJson.get(key).asString == value.toString())
+            compare(key, requestValue, expectedValue)
+            bodyJson.remove(key)
         } catch (_: NullPointerException) {
             fail("Key '$key' was missing in the request body")
         } catch (_: AssertionError) {
-            fail("Expected $value but got ${bodyJson.get(key)}")
+            fail("Expected $expectedValue but got $requestValue")
         } catch (e: Exception) {
             fail(e.message)
         }
+    }
+    assert(bodyJson.size() == 0) {
+        "The following keys were found in the request and were unexpected: ${bodyJson.keySet()}"
     }
 }
 

--- a/sdk/src/test/java/com/stytch/sdk/utils/RecordedRequestExtensions.kt
+++ b/sdk/src/test/java/com/stytch/sdk/utils/RecordedRequestExtensions.kt
@@ -1,0 +1,43 @@
+package com.stytch.sdk.utils
+
+import com.google.gson.JsonParser
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Assert.fail
+
+private fun RecordedRequest.verify(
+    expectedMethod: String,
+    expectedPath: String,
+    expectedBody: Map<String, Any>,
+) {
+    assert(method == expectedMethod)
+    assert(path == expectedPath)
+    var bodyString = body.readUtf8()
+    if (bodyString.isEmpty()) {
+        bodyString = "{}"
+    }
+    val bodyJson = JsonParser.parseString(bodyString).asJsonObject
+    expectedBody.forEach { (key, value) ->
+        try {
+            assert(bodyJson.get(key).asString == value.toString())
+        } catch (_: NullPointerException) {
+            fail("Key '$key' was missing in the request body")
+        } catch (_: AssertionError) {
+            fail("Expected $value but got ${bodyJson.get(key)}")
+        } catch (e: Exception) {
+            fail(e.message)
+        }
+    }
+}
+
+internal fun RecordedRequest.verifyPost(
+    expectedPath: String,
+    expectedBody: Map<String, Any> = emptyMap()
+) = verify("POST", expectedPath, expectedBody)
+
+internal fun RecordedRequest.verifyGet(
+    expectedPath: String
+) = verify("GET", expectedPath, emptyMap())
+
+internal fun RecordedRequest.verifyDelete(
+    expectedPath: String,
+) = verify("DELETE", expectedPath, emptyMap())


### PR DESCRIPTION
Linear Ticket: [SDK-749](https://linear.app/stytch/issue/SDK-749)

## Changes:

1. Update PR template
2. Reduce boilerplate code in `StytchApiServiceTests.kt`
3. Document why we're ignoring exceptions in these tests, and limit the exception to the intended ignored one, so any other exceptions are still surfaced
4. Add verifyGet/verifyDelete/verifyPost helpers to explicitly check request body parameters
