### PR TITLE
Feature/SDK-781 READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,35 +50,35 @@ There are a number of authentication products currently supported by the SDK, wi
 the near future! The full list of currently supported products is as follows:
 
 #### **For Consumer Applications:**
-- Magic links
+- [Magic links](sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/README.md)
     - Send/authenticate magic links via Email
-- OTPs
+- [OTPs](sdk/src/main/java/com/stytch/sdk/consumer/otp/README.md)
     - Send/authenticate one-time passcodes via SMS, WhatsApp, Email
-- Passwords
+- [Passwords](sdk/src/main/java/com/stytch/sdk/consumer/passwords/README.md)
     - Create or authenticate a user
     - Check password strength
     - Reset a password
-- Sessions
+- [Sessions](sdk/src/main/java/com/stytch/sdk/consumer/sessions/README.md)
     - Authenticate/refresh an existing session
     - Revoke a session (Sign out)
-- Biometrics
+- [Biometrics](sdk/src/main/java/com/stytch/sdk/consumer/biometrics/README.md)
     - Register/authenticate with biometrics
-- OAuth
+- [OAuth](sdk/src/main/java/com/stytch/sdk/consumer/oauth/README.md)
     - Register/authenticate with native Google OneTap
     - Register/authenticate with our supported third-party OAuth providers (Amazon, BitBucket, Coinbase, Discord, Facebook, Github, GitLab, Google, LinkedIn, Microsoft, Slack, or Twitch)
-- User Management
+- [User Management](sdk/src/main/java/com/stytch/sdk/consumer/userManagement/README.md)
     - Get or fetch the current user object (sync/cached or async options available)
     - Delete factors by id from the current user
 
 #### **For B2B Applications:**
-- Magic links
+- [Magic links](sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/README.md)
     - Send/authenticate magic links via Email
-- Sessions
+- [Sessions](sdk/src/main/java/com/stytch/sdk/b2b/sessions/README.md)
     - Authenticate/refresh an existing session
     - Revoke a session (Sign out)
-- Members
+- [Members](sdk/src/main/java/com/stytch/sdk/b2b/member/README.md)
     - Get or fetch the current user object (sync/cached or async options available)
-- Organizations
+- [Organizations](sdk/src/main/java/com/stytch/sdk/b2b/organization/README.md)
     - Get or fetch the current user's organization
 
 #### **Async Options**
@@ -253,7 +253,7 @@ fun loginOrCreateSMS() {
 
 ## Documentation
 
-Additional documentation is available for the [consumer](sdk/src/main/java/com/stytch/sdk/consumer/) and [B2B](sdk/src/main/java/com/stytch/sdk/b2b) SDKs within this repository.
+Additional documentation is available for the [consumer](sdk/src/main/java/com/stytch/sdk/consumer/README.md) and [B2B](sdk/src/main/java/com/stytch/sdk/b2b/README.md) SDKs within this repository.
 
 Full reference documentation is available [here](https://stytchauth.github.io/stytch-kotlin/).
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ Add the Stytch dependency to your `app/build.gradle` file:
 
 ```implementation 'com.stytch.sdk:sdk:latest'```
 
+Add the necessary manifest placeholders for our OAuth manager/receiver activities (if you are not using our Third-Party OAuth providers, you must still include this, but can leave the values blank). These values can be any valid scheme or host, and do not relate to your OAuth settings in the Stytch Dashboard. These are only used internally within your app to register a receiver activity. More information is available in the [Consumer OAuth documentation](sdk/src/main/java/com/stytch/sdk/consumer/oauth).
+```
+android {
+    defaultConfig {
+        manifestPlaceholders = [
+            'stytchOAuthRedirectScheme': '[YOUR_AUTH_SCHEME]', // eg: 'app'
+            'stytchOAuthRedirectHost': '[YOUR_AUTH_HOST]', // eg: 'myhost'
+        ]
+    }
+}
+```
+
 ### Getting app secrets ready
 
 1. Go to https://stytch.com/dashboard, and sign up/log in with your email address.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,25 @@
 ![Stytch Android SDK](assets/Wordmark-dark-mode.png#gh-dark-mode-only)
 ![Stytch Android SDK](assets/Wordmark-light-mode.png#gh-light-mode-only)
 
+![Language][language-shield]
+[![Release][release-shield]][release-url]
+[![MIT License][license-shield]][license-url]
+[![Contributors][contributors-shield]][contributors-url]
+[![Issues][issues-shield]][issues-url]
+
+## Table of Contents
 * [Getting Started](#getting-started)
     * [What is Stytch?](#what-is-stytch)
     * [Why should I use the Stytch SDK?](#why-should-i-use-the-stytch-sdk)
     * [What can I do with the Stytch SDK?](#what-can-i-do-with-the-stytch-sdk)
+        * [Consumer Applications](#for-consumer-applications)
+        * [B2B Applications](#for-b2b-applications)
         * [Async Options](#async-options)
     * [How do I start using Stytch?](#how-do-i-start-using-stytch)
 * [Requirements](#requirements)
 * [Installation and setup](#installation-and-setup)
+    * [Consumer Applications](#for-consumer-applications-1)
+    * [B2B Applications](#for-b2b-applications-1)
 * [Usage](#usage)
     * [Deeplink Handling](#deeplink-handling)
     * [Example app](#example-app)
@@ -33,25 +44,12 @@ Stytch's SDKs make it simple to seamlessly onboard, authenticate, and engage use
 way for you to use Stytch on Android. With just a few lines of code, you can easily authenticate your users and get back
 to focusing on the core of your product.
 
-```kotlin
-import com.stytch.sdk.StytchClient
-
-// Initialize StytchClient
-StytchClient.configure(
-    context = application.applicationContext,
-    publicToken = BuildConfig.STYTCH_PUBLIC_TOKEN
-)
-// Later, handle the subsequent deeplink
-viewModelScope.launch {
-    val result = StytchClient.handle(uri = uri, sessionDurationMinutes = 60u)
-}
-```
-
 ### What can I do with the Stytch SDK?
 
 There are a number of authentication products currently supported by the SDK, with additional functionality coming in
 the near future! The full list of currently supported products is as follows:
 
+#### **For Consumer Applications:**
 - Magic links
     - Send/authenticate magic links via Email
 - OTPs
@@ -63,8 +61,27 @@ the near future! The full list of currently supported products is as follows:
 - Sessions
     - Authenticate/refresh an existing session
     - Revoke a session (Sign out)
+- Biometrics
+    - Register/authenticate with biometrics
+- OAuth
+    - Register/authenticate with native Google OneTap
+    - Register/authenticate with our supported third-party OAuth providers (Amazon, BitBucket, Coinbase, Discord, Facebook, Github, GitLab, Google, LinkedIn, Microsoft, Slack, or Twitch)
+- User Management
+    - Get or fetch the current user object (sync/cached or async options available)
+    - Delete factors by id from the current user
 
-#### Async Options
+#### **For B2B Applications:**
+- Magic links
+    - Send/authenticate magic links via Email
+- Sessions
+    - Authenticate/refresh an existing session
+    - Revoke a session (Sign out)
+- Members
+    - Get or fetch the current user object (sync/cached or async options available)
+- Organizations
+    - Get or fetch the current user's organization
+
+#### **Async Options**
 
 The SDK provides several different mechanisms for handling the asynchronous code, so you can choose what best suits your
 needs.
@@ -82,14 +99,14 @@ to `Authorized environments` and enabling any `Auth methods` you wish to use.
 
 ## Requirements
 
-This SDK supports Android API level 21 and
+This SDK supports Android API level 23 and
 above ([distribution stats](https://developer.android.com/about/dashboards/index.html))
 
 ## Installation and setup
 
-Add the Stytch dependency to your app/build.gradle file:
+Add the Stytch dependency to your `app/build.gradle` file:
 
-`implementation 'com.stytch.sdk:sdk:latest'`
+```implementation 'com.stytch.sdk:sdk:latest'```
 
 ### Getting app secrets ready
 
@@ -98,13 +115,23 @@ Add the Stytch dependency to your app/build.gradle file:
 2. Once you are on the dashboard, click on the "API Keys" tab on the left. Scroll down to the "Public tokens" section
    and copy your public token.
 
-3. In your android app, before you can any other part of the Stytch SDK, you must first call
-   the `StytchClient.configure` function and pass in your public token along with the host url:
+3. In your android app, before you call any other part of the Stytch SDK, you must first call
+   the `StytchClient.configure` function and pass in your applicationContext and public token:
 
+#### **For Consumer Applications:**
 ```kotlin
-import com.stytch.sdk.StytchClient
+import com.stytch.sdk.consumer.StytchClient
 
 StytchClient.configure(
+    context = application.applicationContext,
+    publicToken = BuildConfig.STYTCH_PUBLIC_TOKEN
+)
+```
+#### **For B2B Applications:**
+```kotlin
+import com.stytch.sdk.b2b.StytchB2BClient
+
+StytchB2BClient.configure(
     context = application.applicationContext,
     publicToken = BuildConfig.STYTCH_PUBLIC_TOKEN
 )
@@ -139,7 +166,9 @@ private fun handleIntent(intent: Intent) {
 #### MainViewModel.kt
 
 ```kotlin
-import com.stytch.sdk.consumer.network.responseData.BasicData
+import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.network.responseData.BasicData
+import com.stytch.sdk.consumer.StytchClient
 
 lateinit var result: StytchResult<BasicData>
 
@@ -173,9 +202,14 @@ With the above in place your app should be ready to accept deeplinks
 
 ### Example app
 
-The above code is used in practice in the Example App, which can be run and used to test out various flows of the SDK.
-In order to run the application, you have to define a gradle property called STYTCH_PUBLIC_TOKEN in your global or local
-gradle.properties. The token can be received in your Stytch dashboard as mentioned before in this README.
+The above code is used in practice in the Example Apps, which can be run and used to test out various flows of the SDK.
+In order to run the application, you have to define some gradle properties in your global or local `gradle.properties`.
+#### **For Consumer Applications**
+- `STYTCH_PUBLIC_TOKEN` - This token can be retrieved from your Stytch dashboard as mentioned before in this README.
+- `GOOGLE_OAUTH_CLIENT_ID` - This client ID is configured in your Google OAuth settings. You can leave it blank if you are not testing Google OneTap
+#### **For B2B Applications**
+- `STYTCH_B2B_PUBLIC_TOKEN` - This token can be retrieved from your Stytch dashboard as mentioned before in this README.
+- `STYTCH_B2B_ORG_ID` - You must create an organization in your Stytch product, and retrieve this ID
 
 ### Authenticating
 
@@ -188,7 +222,9 @@ This example shows a hypothetical function you could use to use SMS authenticati
 work to the StytchClient under the hood.
 
 ```kotlin
-import com.stytch.sdk.StytchClient
+import com.stytch.sdk.common.StytchResult
+import com.stytch.sdk.common.network.responseData.BasicData
+import com.stytch.sdk.consumer.StytchClient
 
 lateinit var result: StytchResult<BasicData>
 
@@ -219,12 +255,22 @@ A. A few things here: 1) the session token/JWT will be stored in/retrieved from 
 
 Q. Are there guides or sample apps available to see this in use?
 
-A. Yes! There is a Demo App included in this repo, available [here](exampleapp).
+A. Yes! There is a Demo App included in this repo, available [here (consumer application)](consumerExampleapp) and [here (B2B application)](b2bExampleapp).
 
 ### Questions?
 
-Feel free to reach out any time at support@stytch.com or in our [Slack](https://join.slack.com/t/stytch/shared_invite/zt-nil4wo92-jApJ9Cl32cJbEd9esKkvyg)
+Feel free to reach out any time at [support@stytch.com](mailto:support@stytch.com), our [Slack](https://join.slack.com/t/stytch/shared_invite/zt-nil4wo92-jApJ9Cl32cJbEd9esKkvyg), or our [forums](https://forum.stytch.com/).
 
 ## License
 
 The Stytch Android SDK is released under the MIT license. See [LICENSE](LICENSE) for details.
+
+[contributors-shield]: https://img.shields.io/github/contributors/stytchauth/stytch-kotlin.svg?style=for-the-badge
+[contributors-url]: https://github.com/stytchauth/stytch-kotlin/graphs/contributors
+[issues-shield]: https://img.shields.io/github/issues/stytchauth/stytch-kotlin.svg?style=for-the-badge
+[issues-url]: https://github.com/stytchauth/stytch-kotlin/issues
+[license-shield]: https://img.shields.io/github/license/stytchauth/stytch-kotlin.svg?style=for-the-badge
+[license-url]: https://github.com/stytchauth/stytch-kotlin/blob/master/LICENSE
+[release-shield]: https://img.shields.io/github/v/release/stytchauth/stytch-kotlin?style=for-the-badge
+[release-url]:https://github.com/stytchauth/stytch-kotlin/releases
+[language-shield]: https://img.shields.io/github/languages/top/stytchauth/stytch-kotlin?style=for-the-badge

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Add the Stytch dependency to your `app/build.gradle` file:
    and copy your public token.
 
 3. In your android app, before you call any other part of the Stytch SDK, you must first call
-   the `StytchClient.configure` function and pass in your applicationContext and public token:
+   the `configure` function and pass in your applicationContext and public token:
 
 #### **For Consumer Applications:**
 ```kotlin
@@ -240,6 +240,8 @@ fun loginOrCreateSMS() {
 ```
 
 ## Documentation
+
+Additional documentation is available for the [consumer](sdk/src/main/java/com/stytch/sdk/consumer/) and [B2B](sdk/src/main/java/com/stytch/sdk/b2b) SDKs within this repository.
 
 Full reference documentation is available [here](https://stytchauth.github.io/stytch-kotlin/).
 

--- a/consumerExampleApp/build.gradle
+++ b/consumerExampleApp/build.gradle
@@ -39,18 +39,6 @@ android {
                 googleOAuthClientId = GOOGLE_OAUTH_CLIENT_ID
             }
             buildConfigField "String", "GOOGLE_OAUTH_CLIENT_ID", "\"$googleOAuthClientId\""
-
-            String b2bPublicToken = System.getenv("STYTCH_B2B_PUBLIC_TOKEN")
-            if (!b2bPublicToken) {
-                b2bPublicToken = STYTCH_B2B_PUBLIC_TOKEN
-            }
-            buildConfigField "String", "STYTCH_B2B_PUBLIC_TOKEN", "\"$b2bPublicToken\""
-
-            String b2bOrganizationId = System.getenv("STYTCH_B2B_ORG_ID")
-            if (!b2bOrganizationId) {
-                b2bOrganizationId = STYTCH_B2B_ORG_ID
-            }
-            buildConfigField "String", "STYTCH_B2B_ORG_ID", "\"$b2bOrganizationId\""
         }
         release {
             minifyEnabled false

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -7,3 +7,8 @@ Linear Ticket: [LINEAR_NUMBER](https://linear.app/stytch/issue/YOUR_TICKET)
 ## Notes:
 
 - 
+
+## Checklist:
+- [ ] I have verified that this change works in the relevant demo app, or N/A
+- [ ] I have added or updated any tests relevant to this change, or N/A
+- [ ] I have updated any relevant README files for this change, or N/A

--- a/sdk/src/main/java/com/stytch/sdk/b2b/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/README.md
@@ -1,0 +1,32 @@
+# Stytch B2B SDK
+Stytch's B2B SDK makes it simple to seamlessly onboard, authenticate, and engage users. This SDK provides the easiest way for you to use Stytch on Android. With just a few lines of code, you can easily authenticate your users and get back to focusing on the core of your product.
+
+## Supported Authentication Products
+- [Magic links](magicLinks)
+    - Send/authenticate magic links via Email
+- [Sessions](sessions)
+    - Authenticate/refresh an existing session
+    - Revoke a session (Sign out)
+- [Member](member)
+    - Get or fetch the current user object (sync/cached or async options available)
+- [Organization](organization)
+    - Get or fetch the current user's organization
+
+## Using the B2B SDK
+The `StytchB2BClient` object is your entrypoint to the Stytch B2B SDK and is how you interact with all of our supported authentication products.
+
+Each endpoint is explained in their respective READMEs and inline-documentation, but there are a few special methods on the `StytchB2BClient` object to document here.
+
+### **Configuration**
+As mentioned in the [toplevel README](/README.md), before making any Stytch authentication requests, you must configure the `StytchB2BClient`:
+```kotlin
+StytchB2BClient.configure(context: Context, publicToken: String)
+```
+This configures the API for authenticating requests and the encrypted storage helper for persisting session data across app launches.
+
+### **Handling Deeplinks**
+`StytchB2BClient.handle()` is the method you call for parsing out and authenticating deeplinks that your application receives. The currently supported deeplink types are: B2B Email Magic Links. This method returns a [DeeplinkHandledStatus](../common/DeeplinkHandledStatus.kt) class which details the result of the authentication call.
+
+For B2B Email Magic Links, it will return a `Handled` class containing either the authenticated response or error.
+
+Any other link types passed to this method will return a `NotHandled` class.

--- a/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -36,8 +36,9 @@ public object StytchB2BClient {
 
     /**
      * Configures the StytchB2BClient, setting the publicToken
+     * @param context The applicationContext of your app
      * @param publicToken Available via the Stytch dashboard in the API keys section
-     * @throws StytchExceptions.Critical - if failed to generate new encryption keys
+     * @throws StytchExceptions.Critical - if we failed to generate new encryption keys
      */
     public fun configure(context: Context, publicToken: String) {
         try {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/README.md
@@ -1,0 +1,8 @@
+# B2B Magic Links
+The [B2BMagicLinks](B2BMagicLinks.kt) interface provides methods for sending and authenticating users with Email Magic Links.
+
+Call the `StytchB2BClient.magicLinks.email.loginOrSignup()` method to request an email magic link for a user to log in or create an account, based on if the email is associated with a user already. A new or pending user will receive a signup magic link. An active user will receive a login magic link.
+
+If you have connected your deeplink handler with `StytchB2BClient`, the resulting magic link should be detected by your application and automatically authenticated (via the `StytchB2BClient.handle()` method). See the instructions in the [top-level README](/README.md) for information on handling deeplink intents.
+
+If you are not using our deeplink handler, you must parse out the token from the deeplink yourself and pass it to the `StytchB2BClient.magicLinks.authenticate()` method.

--- a/sdk/src/main/java/com/stytch/sdk/b2b/member/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/member/README.md
@@ -1,0 +1,6 @@
+# B2B Member
+The [Member](Member.kt) interface provides methods for retrieving the current authenticated user.
+
+You can choose to get the local representation of the user, without making a network request, with the `StytchClient.member.getSync()` method.
+
+If you want to get the freshest representation of the user from the Stytch servers, use the `StytchClient.member.get()` method.

--- a/sdk/src/main/java/com/stytch/sdk/b2b/organization/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/organization/README.md
@@ -1,0 +1,4 @@
+# B2B Organization
+The [Organization](Organization.kt) interface provides methods for retrieving the current authenticated user's organization.
+
+Call the `StytchClient.organization.get()` method to retrieve this information.

--- a/sdk/src/main/java/com/stytch/sdk/b2b/sessions/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/sessions/README.md
@@ -1,0 +1,8 @@
+# B2B Sessions
+The [B2BSessions](B2BSessions.kt) interface provides methods for authenticating, updating, or revoking sessions, and properties to retrieve the existing session token (opaque or JWT).
+
+Call the `StytchB2BClient.sessions.authenticate()` method to authenticate a Session and (optionally) update its lifetime by the specified sessionDurationMinutes. If the sessionDurationMinutes is not specified, a Session will not be extended.
+
+Call the `StytchB2BClient.sessions.updateSession()` method to update the existing session with new session data.
+
+Call the `StytchB2BClient.sessions.revoke()` method to revoke the current session and immediately invalidate all of its tokens.

--- a/sdk/src/main/java/com/stytch/sdk/consumer/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/README.md
@@ -1,0 +1,44 @@
+# Stytch Consumer SDK
+Stytch's consumer SDK makes it simple to seamlessly onboard, authenticate, and engage users. This SDK provides the easiest way for you to use Stytch on Android. With just a few lines of code, you can easily authenticate your users and get back to focusing on the core of your product.
+
+## Supported Authentication Products
+- [Magic links](magicLinks)
+    - Send/authenticate magic links via Email
+- [OTPs](otp)
+    - Send/authenticate one-time passcodes via SMS, WhatsApp, Email
+- [Passwords](passwords)
+    - Create or authenticate a user
+    - Check password strength
+    - Reset a password
+- [Sessions](sessions)
+    - Authenticate/refresh an existing session
+    - Revoke a session (Sign out)
+- [Biometrics](biometrics)
+    - Register/authenticate with biometrics
+- [OAuth](oauth)
+    - Register/authenticate with native Google OneTap
+    - Register/authenticate with our supported third-party OAuth providers (Amazon, BitBucket, Coinbase, Discord, Facebook, Github, GitLab, Google, LinkedIn, Microsoft, Slack, or Twitch)
+- [User Management](userManagement)
+    - Get or fetch the current user object (sync/cached or async options available)
+    - Delete factors by id from the current user
+
+## Using the Consumer SDK
+The `StytchClient` object is your entrypoint to the Stytch Consumer SDK and is how you interact with all of our supported authentication products.
+
+Each endpoint is explained in their respective READMEs and inline-documentation, but there are a few special methods on the `StytchClient` object to document here.
+
+### **Configuration**
+As mentioned in the [toplevel README](/README.md), before making any Stytch authentication requests, you must configure the `StytchClient`:
+```kotlin
+StytchClient.configure(context: Context, publicToken: String)
+```
+This configures the API for authenticating requests and the encrypted storage helper for persisting session data across app launches.
+
+### **Handling Deeplinks**
+`StytchClient.handle()` is the method you call for parsing out and authenticating deeplinks that your application receives. The currently supported deeplink types are: Email Magic Links, Third-Party OAuth, and Password resets. This method returns a [DeeplinkHandledStatus](../common/DeeplinkHandledStatus.kt) class which details the result of the authentication call.
+
+For Email Magic Links and Third-Party OAuth deeplinks, it will return a `Handled` class containing either the authenticated response or error.
+
+For Password Reset deeplinks, it will return a `ManualHandlingRequired` class containing the relevant token, so that you can provide an appropriate UI to the user for resetting their password. The returned token is used for making the subsequent `StytchClient.passwords.resetByEmail()` call.
+
+Any other link types passed to this method will return a `NotHandled` class.

--- a/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -44,8 +44,9 @@ public object StytchClient {
 
     /**
      * Configures the StytchClient, setting the publicToken.
+     * @param context The applicationContext of your app
      * @param publicToken Available via the Stytch dashboard in the API keys section
-     * @throws StytchExceptions.Critical - if failed to generate new encryption keys
+     * @throws StytchExceptions.Critical - if we failed to generate new encryption keys
      */
     public fun configure(context: Context, publicToken: String) {
         try {

--- a/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/README.md
@@ -1,0 +1,14 @@
+# Consumer Biometrics
+The [Biometrics](Biometrics.kt) interface provides methods for detecting biometric availability, registering, authenticating, and removing biometrics identifiers.
+
+Before beginning a biometric registration, there are two important calls to make:
+1. `StytchClient.biometrics.areBiometricsAvailable()` will tell you if biometrics are possible on this device, given it's sensors, Android version, existing registrations, etc.
+2. `StytchClient.biometrics.isUsingKeystore()` will report whether or not this device has a reliable version of the Android KeyStore. If it does not, there may be issues creating encryption keys, as well as implications on where these keys are stored. The safest approach is to not offer biometrics if this returns `false`, but it is possible to force a registration with an unreliable KeyStore.
+
+If you would like to begin a biometric registration flow, call the `StytchClient.biometrics.register()` method. By default, this method will disallow registrations when the device has an unreliable Android KeyStore. If you are sure you wish to offer biometric authentication on those devices, you must set `allowFallbackToCleartext` to `true` in the `Biometrics.RegisterParameters`.
+
+To determine if a biometric registration exists, call the `StytchClient.biometrics.isRegistrationAvailable()` method.
+
+If a biometric registration exists, you can call the `StytchClient.biometrics.authenticate()` method to begin the authentication flow.
+
+To remove a biometric registration, call `StytchClient.biometrics.removeRegistration()`. This will remove the registration from both the device and the Stytch User object.

--- a/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/biometrics/README.md
@@ -2,7 +2,7 @@
 The [Biometrics](Biometrics.kt) interface provides methods for detecting biometric availability, registering, authenticating, and removing biometrics identifiers.
 
 Before beginning a biometric registration, there are two important calls to make:
-1. `StytchClient.biometrics.areBiometricsAvailable()` will tell you if biometrics are possible on this device, given it's sensors, Android version, existing registrations, etc.
+1. `StytchClient.biometrics.areBiometricsAvailable()` will tell you if biometrics are possible on this device, given its sensors, Android version, existing registrations, etc.
 2. `StytchClient.biometrics.isUsingKeystore()` will report whether or not this device has a reliable version of the Android KeyStore. If it does not, there may be issues creating encryption keys, as well as implications on where these keys are stored. The safest approach is to not offer biometrics if this returns `false`, but it is possible to force a registration with an unreliable KeyStore.
 
 If you would like to begin a biometric registration flow, call the `StytchClient.biometrics.register()` method. By default, this method will disallow registrations when the device has an unreliable Android KeyStore. If you are sure you wish to offer biometric authentication on those devices, you must set `allowFallbackToCleartext` to `true` in the `Biometrics.RegisterParameters`.

--- a/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/magicLinks/README.md
@@ -1,0 +1,10 @@
+# Consumer Magic Links
+The [MagicLinks](MagicLinks.kt) interface provides methods for sending and authenticating users with Email Magic Links.
+
+Call the `StytchClient.magicLinks.email.loginOrCreate()` method to request an email magic link for a user to log in or create an account, based on if the email is associated with a user already. A new or pending user will receive a signup magic link. An active user will receive a login magic link.
+
+Call the `StytchClient.magicLinks.email.send()` method to request an email magic link for an existing user to authenticate.
+
+If you have connected your deeplink handler with `StytchClient`, the resulting magic link should be detected by your application and automatically authenticated (via the `StytchClient.handle()` method). See the instructions in the [top-level README](/README.md) for information on handling deeplink intents.
+
+If you are not using our deeplink handler, you must parse out the token from the deeplink yourself and pass it to the `StytchClient.magicLinks.authenticate()` method.

--- a/sdk/src/main/java/com/stytch/sdk/consumer/oauth/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/oauth/README.md
@@ -1,0 +1,102 @@
+# Consumer OAuth
+The [OAuth](OAuth.kt) interface provides methods for authenticating a user via a native Google OneTap prompt or any of the following third-party OAuth providers, provided you have configured them within your Stytch Dashboard:
+- Amazon
+- BitBucket
+- Coinbase
+- Discord
+- Facebook
+- Github
+- GitLab
+- Google
+- LinkedIn
+- Microsoft
+- Slack
+- Twitch
+
+## Google OneTap
+In order to use Google OneTap, you must register an activity result listener in your activity to listen for the intent returned by Google, which you will use to authenticate the request with Stytch.
+
+First, define a unique identifier for the activity result, which you will use to both start the Google OneTap flow and listen for the activity result:
+```kotlin
+const val GOOGLE_OAUTH_REQUEST=123
+```
+
+Second, in your activity, add a listener for that unique identifier in `onActivityResult`, like so:
+```kotlin
+...
+class MyActivity : AppCompatActivity() {
+    public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        when (requestCode) {
+            GOOGLE_OAUTH_REQUEST -> data?.let { viewModel.authenticateGoogleOneTapLogin(it) }
+        }
+    }
+}
+```
+
+Third, begin the Google OneTap flow by calling the `StytchClient.oauth.googleOneTap.start()` method making sure to provide the unique identifier created above.
+
+Lastly, in your viewmodel for this example, you can authenticate the request by calling the `StytchClient.oauth.googleOneTap.authenticate()` method.
+
+## Third Party OAuth
+In order to use Third-party OAuth flows, there are a few settings you need to configure in your application.
+
+First, ensure you have added the relevant manifest placeholders in your application's `build.gradle` file (as explained in the [top-level README](/README.md)).
+
+Second, similar to the Google OneTap configuration, you must specify a unique identifier for the activity result:
+```kotlin
+const val THIRD_PARTY_OAUTH_REQUEST = 456
+```
+
+Third, in your activity, add a listener for that unique identifier in `onActivityResult`, like so:
+```kotlin
+...
+class MyActivity : AppCompatActivity() {
+    public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        when (requestCode) {
+            THIRD_PARTY_OAUTH_REQUEST -> data?.let { viewModel.authenticateThirdPartyOAuth(resultCode, it) }
+        }
+    }
+}
+```
+
+To begin a Third-party OAuth flow, call the `StytchClient.oauth.[PROVIDER].start()` method, ensuring you pass in the unique third-party OAuth identifier defined previously. This will spawn a new (manager) activity that opens the user's default browser to begin the authentication flow. When the authentication flow has concluded, a new receiver activity intercepts the result, and returns it to the manager activity, which ultimately returns a response to your activity. This helps keep the backstack in order.
+
+Once your listener has retrieved the `resultCode` and `Intent` from the activity listener, you can pass both to the `StytchClient.oauth.authenticate()` method to complete the authentication flow.
+
+The below diagram explains more about the manager/receiver activities and how they relate to the backstack:
+
+ ```kotlin
+ 
+                           Back Stack Towards Top
+                 +------------------------------------------>
+ 
+  +------------+            +---------------+      +----------------+      +--------------+
+  |            |     (1)    |               | (2)  |                | (S1) |              |
+  | Initiating +----------->| OAuthManager  +----->| Authorization  +----->| OAuthReceiver|
+  |  Activity  |            |   Activity    |      |   Activity     |      |   Activity   |
+  |            |<-----------+               |<-----+ (e.g. browser) |      |              |
+  |            | (S3, C2)   |               | (C1) |                |      |              |
+  +------------+            +-------+-------+      +----------------+      +-------+------+
+                                   ^                                              |
+                                   |                   (S2)                       |
+                                   +----------------------------------------------+
+ 
+  - Step 1: ThirdPartyOAuth intiates an intent which launches this (no-ui) activity
+  - Step 2: This activity determines the best browser to launch the authorization flow in, and launches it. Depending
+    on user action, we then enter either a cancellation (C)  or success (S) flow
+ 
+  Cancellation (C) flow:
+  If the user cancels the authorization, we are returned to this Activity at the top of the backstack (C1). Since no
+  return URI is provided, we know the user cancelled, and return a RESULT_CANCELED result for the original intent (C2)
+  and finish the activity. The calling activity will listen for this result and either provide messaging for the user
+  if the error returned is one of NO_BROWSER_FOUND or NO_URI_FOUND, or (most likely) do nothing if it is USER_CANCELED.
+ 
+  Success (S) flow:
+  When the user completes authorization, the OAuthReceiverActivity is launched (S1), as specified in the manifest. That
+  activity will launch this activity (S2) via an intent with CLEAR_TOP set, so that the authorization activity and
+  receiver activity are destroyed leaving this activity at the top of the backstack. This activity will then return a
+  RESULT_OK status for the original intent and pass along the returned URI, then finish itself (S3). The calling
+  activity will listen for this result and use the returned URI to make the authorization call to the Stytch API.
+ ```

--- a/sdk/src/main/java/com/stytch/sdk/consumer/otp/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/otp/README.md
@@ -1,0 +1,8 @@
+# Consumer OTPs
+The [OTP](OTP.kt) interface provides methods for sending and authenticating One-Time Passcodes (OTP) via SMS, WhatsApp, and Email.
+
+Call the `StytchClient.otp.[PLATFORM].loginOrCreate()` method (for your desired platform: `sms`, `whatsapp`, or `email`) to send a one-time passcode (OTP) to a user using their phone number or email address. If the phone number or email address is not associated with a user already, a user will be created. Make sure to persist the returned phone or email ID for use when authenticating an OTP.
+
+Call the `StytchClient.otp.[PLATFORM].send()` method (for your desired platform: `sms`, `whatsapp`, or `email`) to send a one-time passcode (OTP) to an existing user using their phone number or email address. Make sure to persist the returned phone or email ID for use when authenticating an OTP.
+
+Call the `StytchClient.otp.authenticate()` method to authenticate a provided OTP. Remember to include the phone or email ID returned from the `loginOrCreate()` or `send()` response.

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/README.md
@@ -1,5 +1,5 @@
 # Consumer Passwords
-The [Passwords](Passwords.kt) interface provides methods for authenticating, creating, resetting, and performin strength checks of passwords.
+The [Passwords](Passwords.kt) interface provides methods for authenticating, creating, resetting, and performing strength checks of passwords.
 
 Call the `StytchClient.passwords.create()` method to create a new user with an email address and password. Only use this for creating new users. Existing passwordless users who wish to create a password need to go through the reset password flow.
 

--- a/sdk/src/main/java/com/stytch/sdk/consumer/passwords/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/passwords/README.md
@@ -1,0 +1,14 @@
+# Consumer Passwords
+The [Passwords](Passwords.kt) interface provides methods for authenticating, creating, resetting, and performin strength checks of passwords.
+
+Call the `StytchClient.passwords.create()` method to create a new user with an email address and password. Only use this for creating new users. Existing passwordless users who wish to create a password need to go through the reset password flow.
+
+Call the `StytchClient.passwords.authenticate()` method to authenticate a user with their email address and password. This method will return an error if the user’s credentials appeared in the HaveIBeenPwned dataset or if a duplicate user is found (eg: Email Magic Links, OAuth).
+
+Call the `StytchClient.passwords.resetByEmailStart()` method to initiate a password reset for the email address provided. This will trigger an email to be sent to the address, containing a magic link that will allow them to set a new password and authenticate.
+
+If you have connected your deeplink handler with `StytchClient`, the resulting magic link should be detected by your application and automatically parsed (via the `StytchClient.handle()` method). See the instructions in the [top-level README](/README.md) for information on handling deeplink intents. You should get a `DeeplinkHandledStatus.ManualHandlingRequired` result, which includes the necessary token for resetting the user's password. If you are not using our deeplink handler, you must parse out the token from the deeplink yourself.
+
+Once you have a password reset token, and have collected the user's new desired password, you can call the `StytchClient.passwords.resetByEmail()` method to finish resetting their password.
+
+Call the `StytchClient.passwords.strengthCheck()` method to check whether or not the user’s provided password is valid, and to provide feedback to the user on how to increase the strength of their password.

--- a/sdk/src/main/java/com/stytch/sdk/consumer/sessions/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/sessions/README.md
@@ -1,0 +1,8 @@
+# Consumer Sessions
+The [Sessions](Sessions.kt) interface provides methods for authenticating, updating, or revoking sessions, and properties to retrieve the existing session token (opaque or JWT).
+
+Call the `StytchClient.sessions.authenticate()` method to authenticate a Session and (optionally) update its lifetime by the specified sessionDurationMinutes. If the sessionDurationMinutes is not specified, a Session will not be extended.
+
+Call the `StytchClient.sessions.updateSession()` method to update the existing session with new session data.
+
+Call the `StytchClient.sessions.revoke()` method to revoke the current session and immediately invalidate all of its tokens.

--- a/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/userManagement/README.md
@@ -1,0 +1,8 @@
+# Consumer User Management
+The [UserManagement](UserManagement.kt) interface provides methods for retrieving an authenticated user and deleting authentication factors from an authenticated user.
+
+You can choose to get the local representation of the user, without making a network request, with the `StytchClient.user.getSyncUser()` method.
+
+If you want to get the freshest representation of the user from the Stytch servers, use the `StytchClient.user.getUser()` method.
+
+To remove an authentication factor from a user, use the `StytchClient.user.deleteFactor()` method.


### PR DESCRIPTION
Linear Ticket: [SDK-781](https://linear.app/stytch/issue/SDK-781)

## Changes:
1. Removes unnecessary BuildConfig strings from consumer example app
2. Updates PR template to remind us to keep our documentation and tests updated
3. Updates the root README to account for newly added authentication products, the split between consumer/B2B, the increased API level, new required configuration steps, etc. Also adds nifty badges!
4. Adds Consumer/B2B and product-specific READMEs

## Notes:
Most of the product specific READMEs are pretty lightweight/inconsequential, but the additional information for things like OAuth and Biometrics are (IMO) best communicated in a README, and it'd be weird to not have them for the other products, so they're there.

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A