### PR TITLE
Fix package name for serializing/deserializing OAuthError classes

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/common/oauth/OAuthError.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/oauth/OAuthError.kt
@@ -24,6 +24,6 @@ public sealed class OAuthError(override val message: String) : Exception(message
         /**
          * A string identifying the class of this Exception for serializing/deserializing the error within an Intent
          */
-        public const val OAUTH_EXCEPTION: String = "com.stytch.sdk.oauth.OAuthError"
+        public const val OAUTH_EXCEPTION: String = "com.stytch.sdk.common.oauth.OAuthError"
     }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-880](https://linear.app/stytch/issue/SDK-880)

## Changes:

1. Update the classname used for serializing/deserializing OAuthError classes

## Notes:

- This doesn't affect functionality and would work regardless, it's just nice to have this match the package name

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A