### PR TITLE
SDK-919 CanHandle

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/b2b/B2BTokenType.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/B2BTokenType.kt
@@ -1,0 +1,29 @@
+package com.stytch.sdk.b2b
+
+import com.stytch.sdk.common.TokenType
+import java.util.Locale
+
+/**
+ * An enum representing the supported (B2B) token types that we can extract from a deeplink
+ */
+public enum class B2BTokenType : TokenType {
+    /**
+     * A B2B Email Magic Link deeplink
+     */
+    MULTI_TENANT_MAGIC_LINKS,
+
+    /**
+     * An unknown deeplink type. It's possible a non-Stytch deeplink was supplied to the Stytch client's handle() method
+     */
+    UNKNOWN;
+
+    internal companion object {
+        fun fromString(typeString: String?): B2BTokenType {
+            return try {
+                valueOf(typeString?.uppercase(Locale.ENGLISH)!!)
+            } catch (_: Exception) {
+                UNKNOWN
+            }
+        }
+    }
+}

--- a/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -17,7 +17,6 @@ import com.stytch.sdk.common.DeeplinkHandledStatus
 import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchExceptions
-import com.stytch.sdk.common.TokenType
 import com.stytch.sdk.common.extensions.getDeviceInfo
 import com.stytch.sdk.common.network.StytchErrorType
 import com.stytch.sdk.common.stytchError
@@ -108,7 +107,7 @@ public object StytchB2BClient {
     public var organization: Organization = OrganizationImpl(
         externalScope,
         dispatchers,
-        StytchB2BApi.Organization,
+        StytchB2BApi.Organization
     )
         get() {
             assertInitialized()
@@ -126,7 +125,7 @@ public object StytchB2BClient {
         externalScope,
         dispatchers,
         sessionStorage,
-        StytchB2BApi.Member,
+        StytchB2BApi.Member
     )
         get() {
             assertInitialized()
@@ -153,8 +152,8 @@ public object StytchB2BClient {
             if (token.isNullOrEmpty()) {
                 return@withContext DeeplinkHandledStatus.NotHandled(StytchErrorType.DEEPLINK_MISSING_TOKEN.message)
             }
-            when (TokenType.fromString(uri.getQueryParameter(Constants.QUERY_TOKEN_TYPE))) {
-                TokenType.MULTI_TENANT_MAGIC_LINKS -> {
+            when (B2BTokenType.fromString(uri.getQueryParameter(Constants.QUERY_TOKEN_TYPE))) {
+                B2BTokenType.MULTI_TENANT_MAGIC_LINKS -> {
                     DeeplinkHandledStatus.Handled(
                         magicLinks.authenticate(B2BMagicLinks.AuthParameters(token, sessionDurationMinutes))
                     )
@@ -189,4 +188,15 @@ public object StytchB2BClient {
             callback(result)
         }
     }
+
+    /**
+     * A helper function for determining whether the deeplink is intended for Stytch. Useful in contexts where your
+     * application makes use of a deeplink coordinator/manager which requires a synchronous determination of whether a
+     * given handler can handle a given URL.
+     *
+     * @param uri intent.data from deep link
+     * @return Boolean
+     */
+    public fun canHandle(uri: Uri): Boolean =
+        B2BTokenType.fromString(uri.getQueryParameter(Constants.QUERY_TOKEN_TYPE)) != B2BTokenType.UNKNOWN
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/TokenType.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/TokenType.kt
@@ -1,43 +1,6 @@
 package com.stytch.sdk.common
 
-import java.util.Locale
-
 /**
- * An enum representing the supported token types that we can extract from a deeplink
+ * An interface representing the supported token types that we can extract from a deeplink
  */
-public enum class TokenType {
-    /**
-     * A Consumer Email Magic Link deeplink
-     */
-    MAGIC_LINKS,
-
-    /**
-     * A B2B Email Magic Link deeplink
-     */
-    MULTI_TENANT_MAGIC_LINKS,
-
-    /**
-     * A Third Party OAuth deeplink
-     */
-    OAUTH,
-
-    /**
-     * A Password Reset deeplink
-     */
-    PASSWORD_RESET,
-
-    /**
-     * An unknown deeplink type. It's possible a non-Stytch deeplink was supplied to the Stytch client's handle() method
-     */
-    UNKNOWN;
-
-    internal companion object {
-        fun fromString(typeString: String?): TokenType {
-            return try {
-                valueOf(typeString?.uppercase(Locale.ENGLISH)!!)
-            } catch (_: Exception) {
-                UNKNOWN
-            }
-        }
-    }
-}
+public interface TokenType

--- a/sdk/src/main/java/com/stytch/sdk/consumer/ConsumerTokenType.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/ConsumerTokenType.kt
@@ -1,0 +1,39 @@
+package com.stytch.sdk.consumer
+
+import com.stytch.sdk.common.TokenType
+import java.util.Locale
+
+/**
+ * An enum representing the supported (consumer) token types that we can extract from a deeplink
+ */
+public enum class ConsumerTokenType : TokenType {
+    /**
+     * A Consumer Email Magic Link deeplink
+     */
+    MAGIC_LINKS,
+
+    /**
+     * A Third Party OAuth deeplink
+     */
+    OAUTH,
+
+    /**
+     * A Password Reset deeplink
+     */
+    PASSWORD_RESET,
+
+    /**
+     * An unknown deeplink type. It's possible a non-Stytch deeplink was supplied to the Stytch client's handle() method
+     */
+    UNKNOWN;
+
+    internal companion object {
+        fun fromString(typeString: String?): ConsumerTokenType {
+            return try {
+                valueOf(typeString?.uppercase(Locale.ENGLISH)!!)
+            } catch (_: Exception) {
+                UNKNOWN
+            }
+        }
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/b2b/B2BTokenTypeTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/B2BTokenTypeTest.kt
@@ -1,0 +1,11 @@
+package com.stytch.sdk.b2b
+
+import org.junit.Test
+
+internal class B2BTokenTypeTest {
+    @Test
+    fun `B2BTokenType fromString returns expected values`() {
+        assert(B2BTokenType.fromString("multi_tenant_magic_links") == B2BTokenType.MULTI_TENANT_MAGIC_LINKS)
+        assert(B2BTokenType.fromString("something_unexpected") == B2BTokenType.UNKNOWN)
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -247,4 +247,15 @@ internal class StytchB2BClientTest {
     fun `stytchError throws IllegalStateException`() {
         stytchError("Test")
     }
+
+    @Test
+    fun `canHandle only returns true for supported token types`() {
+        val uri = mockk<Uri>()
+        every { uri.getQueryParameter(any()) } returns "MULTI_TENANT_MAGIC_LINKS"
+        assert(StytchB2BClient.canHandle(uri))
+        every { uri.getQueryParameter(any()) } returns "MAGIC_LINKS"
+        assert(!StytchB2BClient.canHandle(uri))
+        every { uri.getQueryParameter(any()) } returns "something random"
+        assert(!StytchB2BClient.canHandle(uri))
+    }
 }

--- a/sdk/src/test/java/com/stytch/sdk/consumer/ConsumerTokenTypeTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/ConsumerTokenTypeTest.kt
@@ -1,0 +1,13 @@
+package com.stytch.sdk.consumer
+
+import org.junit.Test
+
+internal class ConsumerTokenTypeTest {
+    @Test
+    fun `B2BTokenType fromString returns expected values`() {
+        assert(ConsumerTokenType.fromString("magic_links") == ConsumerTokenType.MAGIC_LINKS)
+        assert(ConsumerTokenType.fromString("oauth") == ConsumerTokenType.OAUTH)
+        assert(ConsumerTokenType.fromString("password_reset") == ConsumerTokenType.PASSWORD_RESET)
+        assert(ConsumerTokenType.fromString("something_unexpected") == ConsumerTokenType.UNKNOWN)
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -290,4 +290,19 @@ internal class StytchClientTest {
     fun `stytchError throws IllegalStateException`() {
         stytchError("Test")
     }
+
+    @Test
+    fun `canHandle only returns true for supported token types`() {
+        val uri = mockk<Uri>()
+        every { uri.getQueryParameter(any()) } returns "MAGIC_LINKS"
+        assert(StytchClient.canHandle(uri))
+        every { uri.getQueryParameter(any()) } returns "OAUTH"
+        assert(StytchClient.canHandle(uri))
+        every { uri.getQueryParameter(any()) } returns "PASSWORD_RESET"
+        assert(StytchClient.canHandle(uri))
+        every { uri.getQueryParameter(any()) } returns "MULTI_TENANT_MAGIC_LINKS"
+        assert(!StytchClient.canHandle(uri))
+        every { uri.getQueryParameter(any()) } returns "something random"
+        assert(!StytchClient.canHandle(uri))
+    }
 }


### PR DESCRIPTION
Linear Ticket: [SDK-919](https://linear.app/stytch/issue/SDK-919)

## Changes:

1. Add canHandle method to clients
2. Split out token types so each client type only returns for their supported tokens
3. Add/update tests

## Notes:
- This is a little bigger than the iOS implementation, because I chose to split out the unique token types between consumer and B2B, so that if a user tries to validate a consumer deep link with a B2B client, it returns as expected. This might be something you want to address in iOS (it's edge-casey, but figured I'd call it out).

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A