### PR TITLE
SDK-941 Add userCreated to native OAuth responses

### DIFF
--- a/sdk/src/main/java/com/stytch/sdk/consumer/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/Typealiases.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.consumer.network.models.BiometricsAuthData
 import com.stytch.sdk.consumer.network.models.CreateResponse
 import com.stytch.sdk.consumer.network.models.DeleteAuthenticationFactorData
 import com.stytch.sdk.consumer.network.models.IAuthData
+import com.stytch.sdk.consumer.network.models.INativeOAuthData
 import com.stytch.sdk.consumer.network.models.OAuthData
 import com.stytch.sdk.consumer.network.models.UserData
 
@@ -14,6 +15,11 @@ import com.stytch.sdk.consumer.network.models.UserData
  * Type alias for StytchResult<IAuthData> used for authentication responses
  */
 public typealias AuthResponse = StytchResult<IAuthData>
+
+/**
+ * Type alias for StytchResult<INativeOAuthData> used for Native OAuth (Google One Tap) authentication responses
+ */
+public typealias NativeOAuthResponse = StytchResult<INativeOAuthData>
 
 /**
  * Type alias for StytchResult<CreateResponse> used for PasswordsCreate responses

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApi.kt
@@ -22,6 +22,7 @@ import com.stytch.sdk.consumer.network.models.BiometricsAuthData
 import com.stytch.sdk.consumer.network.models.ConsumerRequests
 import com.stytch.sdk.consumer.network.models.CreateResponse
 import com.stytch.sdk.consumer.network.models.DeleteAuthenticationFactorData
+import com.stytch.sdk.consumer.network.models.NativeOAuthData
 import com.stytch.sdk.consumer.network.models.UserData
 import java.lang.RuntimeException
 
@@ -494,7 +495,7 @@ internal object StytchApi {
             idToken: String,
             nonce: String,
             sessionDurationMinutes: UInt,
-        ): StytchResult<AuthData> = safeConsumerApiCall {
+        ): StytchResult<NativeOAuthData> = safeConsumerApiCall {
             apiService.authenticateWithGoogleIdToken(
                 ConsumerRequests.OAuth.Google.AuthenticateRequest(
                     idToken = idToken,

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
@@ -172,7 +172,7 @@ internal interface StytchApiService : ApiService {
     @POST("oauth/google/id_token/authenticate")
     suspend fun authenticateWithGoogleIdToken(
         @Body request: ConsumerRequests.OAuth.Google.AuthenticateRequest
-    ): ConsumerResponses.AuthenticateResponse
+    ): ConsumerResponses.OAuth.NativeOAuthAuthenticateResponse
 
     @POST("oauth/authenticate")
     suspend fun authenticateWithThirdPartyToken(

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ConsumerResponses.kt
@@ -33,6 +33,9 @@ internal object ConsumerResponses {
     object OAuth {
         @JsonClass(generateAdapter = true)
         class OAuthAuthenticateResponse(data: OAuthData) : StytchDataResponse<OAuthData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class NativeOAuthAuthenticateResponse(data: NativeOAuthData) : StytchDataResponse<NativeOAuthData>(data)
     }
 
     @JsonClass(generateAdapter = true)

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/models/ResponseData.kt
@@ -21,6 +21,10 @@ public interface IAuthData : CommonAuthenticationData {
     public val user: UserData
 }
 
+public interface INativeOAuthData : IAuthData {
+    public val userCreated: Boolean
+}
+
 @JsonClass(generateAdapter = true)
 public data class AuthData(
     @Json(name = "status_code")
@@ -167,3 +171,15 @@ public data class OAuthData(
         val scopes: List<String>,
     )
 }
+
+@JsonClass(generateAdapter = true)
+public data class NativeOAuthData(
+    override val session: SessionData,
+    @Json(name = "session_jwt")
+    override val sessionJwt: String,
+    @Json(name = "session_token")
+    override val sessionToken: String,
+    override val user: UserData,
+    @Json(name = "user_created")
+    override val userCreated: Boolean
+) : INativeOAuthData

--- a/sdk/src/main/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImpl.kt
@@ -11,7 +11,7 @@ import com.stytch.sdk.common.StytchLog
 import com.stytch.sdk.common.StytchResult
 import com.stytch.sdk.common.network.StytchErrorType
 import com.stytch.sdk.common.oauth.GoogleOneTapProvider
-import com.stytch.sdk.consumer.AuthResponse
+import com.stytch.sdk.consumer.NativeOAuthResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
@@ -83,7 +83,7 @@ internal class GoogleOneTapImpl(
         }
     }
 
-    override suspend fun authenticate(parameters: OAuth.GoogleOneTap.AuthenticateParameters): AuthResponse {
+    override suspend fun authenticate(parameters: OAuth.GoogleOneTap.AuthenticateParameters): NativeOAuthResponse {
         if (!::nonce.isInitialized || !::oneTapClient.isInitialized) {
             return StytchResult.Error(StytchExceptions.Input(StytchErrorType.GOOGLE_ONETAP_MISSING_MEMBER.message))
         }
@@ -107,7 +107,10 @@ internal class GoogleOneTapImpl(
         }
     }
 
-    override fun authenticate(parameters: OAuth.GoogleOneTap.AuthenticateParameters, callback: (AuthResponse) -> Unit) {
+    override fun authenticate(
+        parameters: OAuth.GoogleOneTap.AuthenticateParameters,
+        callback: (NativeOAuthResponse) -> Unit
+    ) {
         externalScope.launch(dispatchers.ui) {
             val result = authenticate(parameters)
             callback(result)

--- a/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/oauth/OAuth.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import com.stytch.sdk.common.Constants
 import com.stytch.sdk.consumer.AuthResponse
+import com.stytch.sdk.consumer.NativeOAuthResponse
 import com.stytch.sdk.consumer.OAuthAuthenticatedResponse
 
 /**
@@ -127,14 +128,14 @@ public interface OAuth {
          * @param parameters required to authenticate the Google OneTap login
          * @return [AuthResponse]
          */
-        public suspend fun authenticate(parameters: AuthenticateParameters): AuthResponse
+        public suspend fun authenticate(parameters: AuthenticateParameters): NativeOAuthResponse
 
         /**
          * Authenticate a Google OneTap login
          * @param parameters required to authenticate the Google OneTap login
          * @param callback a callback that receives an [AuthResponse]
          */
-        public fun authenticate(parameters: AuthenticateParameters, callback: (AuthResponse) -> Unit)
+        public fun authenticate(parameters: AuthenticateParameters, callback: (NativeOAuthResponse) -> Unit)
 
         /**
          * Sign a user out of Google Play Services

--- a/sdk/src/test/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/oauth/GoogleOneTapImplTest.kt
@@ -19,7 +19,7 @@ import com.stytch.sdk.common.sessions.SessionAutoUpdater
 import com.stytch.sdk.consumer.AuthResponse
 import com.stytch.sdk.consumer.extensions.launchSessionUpdater
 import com.stytch.sdk.consumer.network.StytchApi
-import com.stytch.sdk.consumer.network.models.AuthData
+import com.stytch.sdk.consumer.network.models.NativeOAuthData
 import com.stytch.sdk.consumer.sessions.ConsumerSessionStorage
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
@@ -244,7 +244,7 @@ internal class GoogleOneTapImplTest {
                 every { googleIdToken } returns ""
             }
         }
-        val mockResponse: StytchResult.Success<AuthData> = mockk {
+        val mockResponse: StytchResult.Success<NativeOAuthData> = mockk {
             every { launchSessionUpdater(any(), any()) } just runs
         }
         coEvery { mockApi.authenticateWithGoogleIdToken(any(), any(), any()) } returns mockResponse


### PR DESCRIPTION
Linear Ticket: [SDK-941](https://linear.app/stytch/issue/SDK-941)

## Changes:
1. Add userCreated to native OAuth responses

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A