### PR TITLE
SDK-962 Discovery endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,17 +81,14 @@ the near future! The full list of currently supported products is as follows:
     - Get or fetch the current user object (sync/cached or async options available)
 - [Organizations](sdk/src/main/java/com/stytch/sdk/b2b/organization/README.md)
     - Get or fetch the current user's organization
-<<<<<<< HEAD
 - [Passwords](sdk/src/main/java/com/stytch/sdk/b2b/passwords/README.md)
   - Authenticate a member by email and password
   - Check password strength
   - Reset a password
-=======
 - [Discovery](sdk/src/main/java/com/stytch/sdk/b2b/discovery/README.md)
   - Create Organizations
   - Exchange sessions between Organizations
   - Find Organizations
->>>>>>> a3b22a1 (Add scaffolding for Discovery endpoints)
 
 #### **Async Options**
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,17 @@ the near future! The full list of currently supported products is as follows:
     - Get or fetch the current user object (sync/cached or async options available)
 - [Organizations](sdk/src/main/java/com/stytch/sdk/b2b/organization/README.md)
     - Get or fetch the current user's organization
+<<<<<<< HEAD
 - [Passwords](sdk/src/main/java/com/stytch/sdk/b2b/passwords/README.md)
   - Authenticate a member by email and password
   - Check password strength
   - Reset a password
+=======
+- [Discovery](sdk/src/main/java/com/stytch/sdk/b2b/discovery/README.md)
+  - Create Organizations
+  - Exchange sessions between Organizations
+  - Find Organizations
+>>>>>>> a3b22a1 (Add scaffolding for Discovery endpoints)
 
 #### **Async Options**
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ the near future! The full list of currently supported products is as follows:
 #### **For B2B Applications:**
 - [Magic links](sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/README.md)
     - Send/authenticate magic links via Email
+    - Send/authenticate discovery magic links via Email
 - [Sessions](sdk/src/main/java/com/stytch/sdk/b2b/sessions/README.md)
     - Authenticate/refresh an existing session
     - Revoke a session (Sign out)

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/DiscoveryViewModel.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/DiscoveryViewModel.kt
@@ -22,14 +22,16 @@ class DiscoveryViewModel : ViewModel() {
     fun organizations() {
         viewModelScope.launchAndToggleLoadingState {
             _currentResponse.value =
-                StytchB2BClient.discovery.organizations(Discovery.DiscoverOrganizationsParameters()).toFriendlyDisplay()
+                StytchB2BClient.discovery.listOrganizations(
+                    Discovery.DiscoverOrganizationsParameters()
+                ).toFriendlyDisplay()
         }
     }
 
     fun createOrganization(intermediateSessionToken: String) {
         viewModelScope.launchAndToggleLoadingState {
             _currentResponse.value =
-                StytchB2BClient.discovery.create(
+                StytchB2BClient.discovery.createOrganization(
                     Discovery.CreateOrganizationParameters(
                         intermediateSessionToken = intermediateSessionToken
                     )

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/DiscoveryViewModel.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/DiscoveryViewModel.kt
@@ -1,0 +1,37 @@
+package com.stytch.exampleapp.b2b
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.stytch.sdk.b2b.StytchB2BClient
+import com.stytch.sdk.b2b.discovery.Discovery
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DisposableHandle
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class DiscoveryViewModel : ViewModel() {
+    private val _currentResponse = MutableStateFlow("")
+    val currentResponse: StateFlow<String>
+        get() = _currentResponse
+
+    private val _loadingState = MutableStateFlow(false)
+    val loadingState: StateFlow<Boolean>
+        get() = _loadingState
+
+    fun organizations() {
+        viewModelScope.launchAndToggleLoadingState {
+            _currentResponse.value =
+                StytchB2BClient.discovery.organizations(Discovery.DiscoverOrganizationsParameters()).toFriendlyDisplay()
+        }
+    }
+
+    private fun CoroutineScope.launchAndToggleLoadingState(block: suspend () -> Unit): DisposableHandle {
+        return launch {
+            _loadingState.value = true
+            block()
+        }.invokeOnCompletion {
+            _loadingState.value = false
+        }
+    }
+}

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/DiscoveryViewModel.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/DiscoveryViewModel.kt
@@ -26,6 +26,16 @@ class DiscoveryViewModel : ViewModel() {
         }
     }
 
+    fun createOrganization(intermediateSessionToken: String) {
+        viewModelScope.launchAndToggleLoadingState {
+            _currentResponse.value =
+                StytchB2BClient.discovery.create(
+                    Discovery.CreateOrganizationParameters(
+                        intermediateSessionToken = intermediateSessionToken
+                    )
+                ).toFriendlyDisplay()
+        }
+    }
     private fun CoroutineScope.launchAndToggleLoadingState(block: suspend () -> Unit): DisposableHandle {
         return launch {
             _loadingState.value = true

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/HomeViewModel.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/HomeViewModel.kt
@@ -68,6 +68,24 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    fun sendDiscoveryMagicLink() {
+        if (emailIsValid) {
+            showEmailError = false
+            viewModelScope.launch {
+                _loadingState.value = true
+                _currentResponse.value = StytchB2BClient.magicLinks.discovery.send(
+                    B2BMagicLinks.DiscoveryMagicLinks.SendParameters(
+                        emailAddress = emailState.text,
+                    )
+                ).toFriendlyDisplay()
+            }.invokeOnCompletion {
+                _loadingState.value = false
+            }
+        } else {
+            showEmailError = true
+        }
+    }
+
     fun revokeSession() {
         viewModelScope.launch {
             _loadingState.value = true

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/HomeViewModel.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/HomeViewModel.kt
@@ -16,7 +16,6 @@ import com.stytch.sdk.common.StytchResult
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 class HomeViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -112,7 +111,6 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                     // Hacking this in for organization discovery stuff
                     ((result.response as? StytchResult.Success<Any>)?.value as? DiscoveryAuthenticateResponseData)
                         ?.let {
-                            Timber.d("INTERMEDIATE = ${it.intermediateSessionToken}")
                             _intermediateSessionToken.value = it.intermediateSessionToken
                         }
                     result.response.toFriendlyDisplay()

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/MainActivity.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/MainActivity.kt
@@ -14,12 +14,13 @@ class MainActivity : FragmentActivity() {
 
     private val homeViewModel: HomeViewModel by viewModels()
     private val passwordsViewModel: PasswordsViewModel by viewModels()
+    private val discoveryViewModel: DiscoveryViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             AppTheme {
-                AppScreen(homeViewModel, passwordsViewModel)
+                AppScreen(homeViewModel, passwordsViewModel, discoveryViewModel)
             }
         }
         if (intent.action == Intent.ACTION_VIEW) {

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/MainActivity.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/MainActivity.kt
@@ -9,7 +9,6 @@ import androidx.fragment.app.FragmentActivity
 import com.stytch.exampleapp.b2b.theme.AppTheme
 import com.stytch.exampleapp.b2b.ui.AppScreen
 
-
 class MainActivity : FragmentActivity() {
 
     private val homeViewModel: HomeViewModel by viewModels()

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/AppScreen.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/AppScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountBox
+import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -30,6 +31,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.stytch.exampleapp.b2b.DiscoveryViewModel
 import com.stytch.exampleapp.b2b.HomeViewModel
 import com.stytch.exampleapp.b2b.PasswordsViewModel
 import com.stytch.exampleapp.b2b.R
@@ -37,12 +39,14 @@ import com.stytch.exampleapp.b2b.R
 val items = listOf(
     Screen.Main,
     Screen.Passwords,
+    Screen.Discovery,
 )
 
 @Composable
 fun AppScreen(
     homeViewModel: HomeViewModel,
     passwordsViewModel: PasswordsViewModel,
+    discoveryViewModel: DiscoveryViewModel,
 ) {
     val navController = rememberNavController()
     Scaffold(
@@ -83,6 +87,7 @@ fun AppScreen(
             NavHost(navController, startDestination = Screen.Main.route, Modifier.padding(padding)) {
                 composable(Screen.Main.route) { MainScreen(viewModel = homeViewModel) }
                 composable(Screen.Passwords.route) { PasswordsScreen(viewModel = passwordsViewModel) }
+                composable(Screen.Discovery.route) { DiscoveryScreen(viewModel = discoveryViewModel) }
             }
         }
     )
@@ -108,4 +113,5 @@ fun Toolbar(toolbarText: String) {
 sealed class Screen(val route: String, @StringRes val resourceId: Int, val iconVector: ImageVector) {
     object Main : Screen("main", R.string.home, Icons.Filled.Home)
     object Passwords : Screen("passwords", R.string.passwords, Icons.Filled.AccountBox)
+    object Discovery : Screen("discovery", R.string.discovery, Icons.Filled.Build)
 }

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/AppScreen.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/AppScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.AccountBox
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -49,6 +50,7 @@ fun AppScreen(
     discoveryViewModel: DiscoveryViewModel,
 ) {
     val navController = rememberNavController()
+    val intermediateSessionTokenValue = homeViewModel.intermediateSessionToken.collectAsState()
     Scaffold(
         modifier = Modifier
             .fillMaxHeight()
@@ -86,8 +88,12 @@ fun AppScreen(
         content = { padding ->
             NavHost(navController, startDestination = Screen.Main.route, Modifier.padding(padding)) {
                 composable(Screen.Main.route) { MainScreen(viewModel = homeViewModel) }
-                composable(Screen.Passwords.route) { PasswordsScreen(viewModel = passwordsViewModel) }
-                composable(Screen.Discovery.route) { DiscoveryScreen(viewModel = discoveryViewModel) }
+                composable(Screen.Discovery.route) {
+                    DiscoveryScreen(
+                        viewModel = discoveryViewModel,
+                        intermediateSessionToken = intermediateSessionTokenValue.value
+                    )
+                }
             }
         }
     )

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/DiscoveryScreen.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/DiscoveryScreen.kt
@@ -1,0 +1,50 @@
+package com.stytch.exampleapp.b2b.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.stytch.exampleapp.b2b.DiscoveryViewModel
+import com.stytch.exampleapp.b2b.R
+
+@Composable
+fun DiscoveryScreen(
+    viewModel: DiscoveryViewModel
+) {
+    val responseState = viewModel.currentResponse.collectAsState()
+    val loading = viewModel.loadingState.collectAsState()
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).weight(1F, false),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.discovery_discover),
+                onClick = viewModel::organizations
+            )
+        }
+        Column(
+            modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).weight(1F, false),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if (loading.value) {
+                CircularProgressIndicator()
+            } else {
+                Text(text = responseState.value, modifier = Modifier.padding(8.dp))
+            }
+        }
+    }
+}

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/DiscoveryScreen.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/DiscoveryScreen.kt
@@ -18,7 +18,8 @@ import com.stytch.exampleapp.b2b.R
 
 @Composable
 fun DiscoveryScreen(
-    viewModel: DiscoveryViewModel
+    viewModel: DiscoveryViewModel,
+    intermediateSessionToken: String = ""
 ) {
     val responseState = viewModel.currentResponse.collectAsState()
     val loading = viewModel.loadingState.collectAsState()
@@ -34,6 +35,12 @@ fun DiscoveryScreen(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.discovery_discover),
                 onClick = viewModel::organizations
+            )
+
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.create_organization),
+                onClick = { viewModel.createOrganization(intermediateSessionToken) }
             )
         }
         Column(

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/MainScreen.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/ui/MainScreen.kt
@@ -79,6 +79,11 @@ fun MainScreen(
             )
             StytchButton(
                 modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.send_discovery_magic_link),
+                onClick = viewModel::sendDiscoveryMagicLink
+            )
+            StytchButton(
+                modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.revoke_session),
                 onClick = { viewModel.revokeSession() }
             )

--- a/b2bExampleApp/src/main/res/values/strings.xml
+++ b/b2bExampleApp/src/main/res/values/strings.xml
@@ -20,4 +20,5 @@
     <string name="button_strengthCheck">Check New Password Strength</string>
     <string name="discovery">Discovery</string>
     <string name="discovery_discover">Discover Organizations</string>
+    <string name="send_discovery_magic_link">Send Discovery Magic Link</string>
 </resources>

--- a/b2bExampleApp/src/main/res/values/strings.xml
+++ b/b2bExampleApp/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="discovery">Discovery</string>
     <string name="discovery_discover">Discover Organizations</string>
     <string name="send_discovery_magic_link">Send Discovery Magic Link</string>
+    <string name="create_organization">Create an organization</string>
 </resources>

--- a/b2bExampleApp/src/main/res/values/strings.xml
+++ b/b2bExampleApp/src/main/res/values/strings.xml
@@ -18,4 +18,6 @@
     <string name="button_resetBySession">Reset By Session</string>
     <string name="button_authenticate">Authenticate</string>
     <string name="button_strengthCheck">Check New Password Strength</string>
+    <string name="discovery">Discovery</string>
+    <string name="discovery_discover">Discover Organizations</string>
 </resources>

--- a/consumerExampleApp/src/main/java/com/stytch/exampleapp/HomeViewModel.kt
+++ b/consumerExampleApp/src/main/java/com/stytch/exampleapp/HomeViewModel.kt
@@ -57,7 +57,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             _loadingState.value = true
             _currentResponse.value = when (val result = StytchClient.handle(uri = uri, sessionDurationMinutes = 60u)) {
                 is DeeplinkHandledStatus.NotHandled -> result.reason
-                is DeeplinkHandledStatus.Handled -> result.response.toFriendlyDisplay()
+                is DeeplinkHandledStatus.Handled -> result.response.result.toFriendlyDisplay()
                 // This only happens for password reset deeplinks
                 is DeeplinkHandledStatus.ManualHandlingRequired ->
                     "Password reset token retrieved, initiate password reset flow"

--- a/sdk/src/main/java/com/stytch/sdk/b2b/B2BTokenType.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/B2BTokenType.kt
@@ -13,6 +13,11 @@ public enum class B2BTokenType : TokenType {
     MULTI_TENANT_MAGIC_LINKS,
 
     /**
+     * A B2B Discovery Magic Link deeplink
+     */
+    DISCOVERY,
+
+    /**
      * An unknown deeplink type. It's possible a non-Stytch deeplink was supplied to the Stytch client's handle() method
      */
     UNKNOWN;

--- a/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -2,6 +2,8 @@ package com.stytch.sdk.b2b
 
 import android.content.Context
 import android.net.Uri
+import com.stytch.sdk.b2b.discovery.Discovery
+import com.stytch.sdk.b2b.discovery.DiscoveryImpl
 import com.stytch.sdk.b2b.magicLinks.B2BMagicLinks
 import com.stytch.sdk.b2b.magicLinks.B2BMagicLinksImpl
 import com.stytch.sdk.b2b.member.Member
@@ -147,6 +149,23 @@ public object StytchB2BClient {
         sessionStorage,
         StorageHelper,
         StytchB2BApi.Passwords,
+    )
+        get() {
+            assertInitialized()
+            return field
+        }
+        internal set
+
+    /**
+     * Exposes an instance of the [Discovery] interface which provides methods for creating and discovering
+     * Organizations and exchanging sessions between organizations
+     *
+     * @throws [stytchError] if you attempt to access this property before calling StytchB2BClient.configure()
+     */
+    public var discovery: Discovery = DiscoveryImpl(
+        externalScope,
+        dispatchers,
+        StytchB2BApi.Discovery,
     )
         get() {
             assertInitialized()

--- a/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -18,6 +18,7 @@ import com.stytch.sdk.b2b.sessions.B2BSessions
 import com.stytch.sdk.b2b.sessions.B2BSessionsImpl
 import com.stytch.sdk.common.Constants
 import com.stytch.sdk.common.DeeplinkHandledStatus
+import com.stytch.sdk.common.DeeplinkResponse
 import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchExceptions
@@ -196,14 +197,18 @@ public object StytchB2BClient {
             when (B2BTokenType.fromString(uri.getQueryParameter(Constants.QUERY_TOKEN_TYPE))) {
                 B2BTokenType.MULTI_TENANT_MAGIC_LINKS -> {
                     DeeplinkHandledStatus.Handled(
-                        magicLinks.authenticate(B2BMagicLinks.AuthParameters(token, sessionDurationMinutes))
+                        DeeplinkResponse.Auth(
+                            magicLinks.authenticate(B2BMagicLinks.AuthParameters(token, sessionDurationMinutes))
+                        )
                     )
                 }
                 B2BTokenType.DISCOVERY -> {
                     DeeplinkHandledStatus.Handled(
-                        magicLinks.discovery.authenticate(
-                            B2BMagicLinks.DiscoveryMagicLinks.AuthenticateParameters(
-                                token = token
+                        DeeplinkResponse.Discovery(
+                            magicLinks.discoveryAuthenticate(
+                                B2BMagicLinks.DiscoveryAuthenticateParameters(
+                                    token = token
+                                )
                             )
                         )
                     )

--- a/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -76,7 +76,8 @@ public object StytchB2BClient {
         dispatchers,
         sessionStorage,
         StorageHelper,
-        StytchB2BApi.MagicLinks.Email
+        StytchB2BApi.MagicLinks.Email,
+        StytchB2BApi.MagicLinks.Discovery,
     )
         get() {
             assertInitialized()
@@ -196,6 +197,15 @@ public object StytchB2BClient {
                 B2BTokenType.MULTI_TENANT_MAGIC_LINKS -> {
                     DeeplinkHandledStatus.Handled(
                         magicLinks.authenticate(B2BMagicLinks.AuthParameters(token, sessionDurationMinutes))
+                    )
+                }
+                B2BTokenType.DISCOVERY -> {
+                    DeeplinkHandledStatus.Handled(
+                        magicLinks.discovery.authenticate(
+                            B2BMagicLinks.DiscoveryMagicLinks.AuthenticateParameters(
+                                token = token
+                            )
+                        )
                     )
                 }
                 else -> {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.b2b
 
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
+import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
 import com.stytch.sdk.b2b.network.models.IB2BAuthData
 import com.stytch.sdk.b2b.network.models.IntermediateSessionExchangeResponseData
@@ -56,3 +57,8 @@ public typealias IntermediateSessionExchangeResponse = StytchResult<Intermediate
  * Type alias for StytchResult<OrganizationCreateResponseData> used for discovery.create() responses
  */
 public typealias OrganizationCreateResponse = StytchResult<OrganizationCreateResponseData>
+
+/**
+ * Type alias for StytchResult<DiscoveryAuthenticateResponseData> used for magicLinks.discovery.authenticate() responses
+ */
+public typealias DiscoveryEMLAuthResponse = StytchResult<DiscoveryAuthenticateResponseData>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -1,8 +1,11 @@
 package com.stytch.sdk.b2b
 
+import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
 import com.stytch.sdk.b2b.network.models.IB2BAuthData
+import com.stytch.sdk.b2b.network.models.IntermediateSessionExchangeResponseData
 import com.stytch.sdk.b2b.network.models.MemberResponseData
+import com.stytch.sdk.b2b.network.models.OrganizationCreateResponseData
 import com.stytch.sdk.b2b.network.models.OrganizationResponseData
 import com.stytch.sdk.b2b.network.models.SessionResetResponseData
 import com.stytch.sdk.b2b.network.models.StrengthCheckResponseData
@@ -37,3 +40,18 @@ public typealias PasswordStrengthCheckResponse = StytchResult<StrengthCheckRespo
  * Type alias for StytchResult<SessionResetResponseData> used for passwords.resetBySession() responses
  */
 public typealias SessionResetResponse = StytchResult<SessionResetResponseData>
+
+/**
+ *
+ */
+public typealias DiscoverOrganizationsResponse = StytchResult<DiscoveredOrganizationsResponseData>
+
+/**
+ *
+ */
+public typealias IntermediateSessionExchangeResponse = StytchResult<IntermediateSessionExchangeResponseData>
+
+/**
+ *
+ */
+public typealias OrganizationCreateResponse = StytchResult<OrganizationCreateResponseData>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/Typealiases.kt
@@ -43,15 +43,16 @@ public typealias SessionResetResponse = StytchResult<SessionResetResponseData>
 
 /**
  *
+ * Type alias for StytchResult<DiscoveredOrganizationsResponseData> used for discovery.organizations() responses
  */
 public typealias DiscoverOrganizationsResponse = StytchResult<DiscoveredOrganizationsResponseData>
 
 /**
- *
+ * Type alias for StytchResult<IntermediateSessionExchangeResponseData> used for discovery.exchangeSession() responses
  */
 public typealias IntermediateSessionExchangeResponse = StytchResult<IntermediateSessionExchangeResponseData>
 
 /**
- *
+ * Type alias for StytchResult<OrganizationCreateResponseData> used for discovery.create() responses
  */
 public typealias OrganizationCreateResponse = StytchResult<OrganizationCreateResponseData>

--- a/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
@@ -24,7 +24,7 @@ public interface Discovery {
     /**
      *
      */
-    public suspend fun organizations(
+    public fun organizations(
         parameters: DiscoverOrganizationsParameters,
         callback: (DiscoverOrganizationsResponse) -> Unit
     )
@@ -46,7 +46,7 @@ public interface Discovery {
     /**
      *
      */
-    public suspend fun exchangeSession(
+    public fun exchangeSession(
         parameters: SessionExchangeParameters,
         callback: (IntermediateSessionExchangeResponse) -> Unit
     )
@@ -70,7 +70,7 @@ public interface Discovery {
     /**
      *
      */
-    public suspend fun create(
+    public fun create(
         parameters: CreateOrganizationParameters,
         callback: (OrganizationCreateResponse) -> Unit
     )

--- a/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
@@ -39,14 +39,14 @@ public interface Discovery {
      * @param parameters required for retrieving a member's available organizations
      * @return [DiscoverOrganizationsResponse]
      */
-    public suspend fun organizations(parameters: DiscoverOrganizationsParameters): DiscoverOrganizationsResponse
+    public suspend fun listOrganizations(parameters: DiscoverOrganizationsParameters): DiscoverOrganizationsResponse
 
     /**
      * Discover a member's available organizations
      * @param parameters required for retrieving a member's available organizations
      * @param callback a callback that receives a [DiscoverOrganizationsResponse]
      */
-    public fun organizations(
+    public fun listOrganizations(
         parameters: DiscoverOrganizationsParameters,
         callback: (DiscoverOrganizationsResponse) -> Unit
     )
@@ -70,7 +70,9 @@ public interface Discovery {
      * @param parameters required for exchanging a session between organizations
      * @return [IntermediateSessionExchangeResponse]
      */
-    public suspend fun exchangeSession(parameters: SessionExchangeParameters): IntermediateSessionExchangeResponse
+    public suspend fun exchangeIntermediateSession(
+        parameters: SessionExchangeParameters
+    ): IntermediateSessionExchangeResponse
 
     /**
      * Exchange an Intermediate Session for a fully realized Member Session in a desired Organization. This operation
@@ -79,7 +81,7 @@ public interface Discovery {
      * @param parameters required for exchanging a session between organizations
      * @param callback a callback that receives an [IntermediateSessionExchangeResponse]
      */
-    public fun exchangeSession(
+    public fun exchangeIntermediateSession(
         parameters: SessionExchangeParameters,
         callback: (IntermediateSessionExchangeResponse) -> Unit
     )
@@ -108,7 +110,7 @@ public interface Discovery {
      * @param parameters required for creating an organization
      * @return [OrganizationCreateResponse]
      */
-    public suspend fun create(parameters: CreateOrganizationParameters): OrganizationCreateResponse
+    public suspend fun createOrganization(parameters: CreateOrganizationParameters): OrganizationCreateResponse
 
     /**
      * Create a new organization. If an end user does not want to join any already-existing organization, or has no
@@ -118,7 +120,7 @@ public interface Discovery {
      * @param parameters required for creating an organization
      * @param callback a callback that receives an [OrganizationCreateResponse]
      */
-    public fun create(
+    public fun createOrganization(
         parameters: CreateOrganizationParameters,
         callback: (OrganizationCreateResponse) -> Unit
     )

--- a/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
@@ -6,23 +6,45 @@ import com.stytch.sdk.b2b.OrganizationCreateResponse
 import com.stytch.sdk.common.Constants
 
 /**
+ * The Discovery interface provides methods for discovering a member's available organizations, creating organizations,
+ * and exchanging sessions between organizations.
+ * The Discovery product lets End Users discover and log in to Organizations they are a Member of, invited to, or
+ * eligible to join.
  *
+ * Unlike our other B2B products, Discovery allows End Users to authenticate without specifying an Organization in
+ * advance. This is done via a Discovery Magic Link flow. After an End User is authenticated, an Intermediate Session
+ * is returned along with a list of associated Organizations.
+ *
+ * The End User can then authenticate to the desired Organization by passing the Intermediate Session and
+ * organization_id. End users can even create a new Organization instead of joining or logging in to an existing one.
+ *
+ * Call the `StytchB2BClient.discovery.organizations()` method to find a member's available organizations.
+ *
+ * Call the `StytchB2BClient.discovery.exchangeSession()` method to exchange a session between organizations.
+ *
+ * Call the `StytchB2BClient.discovery.create()` method to create a new organization.
  */
 public interface Discovery {
     /**
-     *
+     * Data class used for wrapping parameters used with Discovering organizations
+     * @property intermediateSessionToken is the unique sequence of characters used to authenticate a member. If this
+     * is not provided the existing session token will be used.
      */
     public data class DiscoverOrganizationsParameters(
         val intermediateSessionToken: String? = null
     )
 
     /**
-     *
+     * Discover a member's available organizations
+     * @param parameters required for retrieving a member's available organizations
+     * @return [DiscoverOrganizationsResponse]
      */
     public suspend fun organizations(parameters: DiscoverOrganizationsParameters): DiscoverOrganizationsResponse
 
     /**
-     *
+     * Discover a member's available organizations
+     * @param parameters required for retrieving a member's available organizations
+     * @param callback a callback that receives a [DiscoverOrganizationsResponse]
      */
     public fun organizations(
         parameters: DiscoverOrganizationsParameters,
@@ -30,7 +52,10 @@ public interface Discovery {
     )
 
     /**
-     *
+     * Data class used for wrapping parameters used with exchanging sessions between organizations.
+     * @property intermediateSessionToken is the unique sequence of characters used to authenticate a member
+     * @property organizationId is the organization ID of the desired organization
+     * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
     public data class SessionExchangeParameters(
         val intermediateSessionToken: String,
@@ -39,12 +64,20 @@ public interface Discovery {
     )
 
     /**
-     *
+     * Exchange an Intermediate Session for a fully realized Member Session in a desired Organization. This operation
+     * consumes the Intermediate Session. This endpoint can be used to accept invites and create new members via domain
+     * matching.
+     * @param parameters required for exchanging a session between organizations
+     * @return [IntermediateSessionExchangeResponse]
      */
     public suspend fun exchangeSession(parameters: SessionExchangeParameters): IntermediateSessionExchangeResponse
 
     /**
-     *
+     * Exchange an Intermediate Session for a fully realized Member Session in a desired Organization. This operation
+     * consumes the Intermediate Session. This endpoint can be used to accept invites and create new members via domain
+     * matching.
+     * @param parameters required for exchanging a session between organizations
+     * @param callback a callback that receives an [IntermediateSessionExchangeResponse]
      */
     public fun exchangeSession(
         parameters: SessionExchangeParameters,
@@ -52,7 +85,12 @@ public interface Discovery {
     )
 
     /**
-     *
+     * A data class used for wrapping parameters used with creating organizations
+     * @property intermediateSessionToken is the unique sequence of characters used to authenticate a member
+     * @property organizationName is the name of the new organization
+     * @property organizationSlug is the desired slug of the new organization
+     * @property organizationLogoUrl is the optional URL of the new organization's logo
+     * @property sessionDurationMinutes indicates how long the session should last before it expires
      */
     public data class CreateOrganizationParameters(
         val intermediateSessionToken: String,
@@ -63,12 +101,22 @@ public interface Discovery {
     )
 
     /**
-     *
+     * Create a new organization. If an end user does not want to join any already-existing organization, or has no
+     * possible organizations to join, this endpoint can be used to create a new Organization and Member. This operation
+     * consumes the Intermediate Session. This endpoint can also be used to start an initial session for the newly
+     * created member and organization.
+     * @param parameters required for creating an organization
+     * @return [OrganizationCreateResponse]
      */
     public suspend fun create(parameters: CreateOrganizationParameters): OrganizationCreateResponse
 
     /**
-     *
+     * Create a new organization. If an end user does not want to join any already-existing organization, or has no
+     * possible organizations to join, this endpoint can be used to create a new Organization and Member. This operation
+     * consumes the Intermediate Session. This endpoint can also be used to start an initial session for the newly
+     * created member and organization.
+     * @param parameters required for creating an organization
+     * @param callback a callback that receives an [OrganizationCreateResponse]
      */
     public fun create(
         parameters: CreateOrganizationParameters,

--- a/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
@@ -1,0 +1,77 @@
+package com.stytch.sdk.b2b.discovery
+
+import com.stytch.sdk.b2b.DiscoverOrganizationsResponse
+import com.stytch.sdk.b2b.IntermediateSessionExchangeResponse
+import com.stytch.sdk.b2b.OrganizationCreateResponse
+import com.stytch.sdk.common.Constants
+
+/**
+ *
+ */
+public interface Discovery {
+    /**
+     *
+     */
+    public data class DiscoverOrganizationsParameters(
+        val intermediateSessionToken: String? = null
+    )
+
+    /**
+     *
+     */
+    public suspend fun organizations(parameters: DiscoverOrganizationsParameters): DiscoverOrganizationsResponse
+
+    /**
+     *
+     */
+    public suspend fun organizations(
+        parameters: DiscoverOrganizationsParameters,
+        callback: (DiscoverOrganizationsResponse) -> Unit
+    )
+
+    /**
+     *
+     */
+    public data class SessionExchangeParameters(
+        val intermediateSessionToken: String,
+        val organizationId: String,
+        val sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
+    )
+
+    /**
+     *
+     */
+    public suspend fun exchangeSession(parameters: SessionExchangeParameters): IntermediateSessionExchangeResponse
+
+    /**
+     *
+     */
+    public suspend fun exchangeSession(
+        parameters: SessionExchangeParameters,
+        callback: (IntermediateSessionExchangeResponse) -> Unit
+    )
+
+    /**
+     *
+     */
+    public data class CreateOrganizationParameters(
+        val intermediateSessionToken: String,
+        val organizationName: String,
+        val organizationSlug: String,
+        val organizationLogoUrl: String? = null,
+        val sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
+    )
+
+    /**
+     *
+     */
+    public suspend fun create(parameters: CreateOrganizationParameters): OrganizationCreateResponse
+
+    /**
+     *
+     */
+    public suspend fun create(
+        parameters: CreateOrganizationParameters,
+        callback: (OrganizationCreateResponse) -> Unit
+    )
+}

--- a/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
@@ -94,8 +94,8 @@ public interface Discovery {
      */
     public data class CreateOrganizationParameters(
         val intermediateSessionToken: String,
-        val organizationName: String,
-        val organizationSlug: String,
+        val organizationName: String? = null,
+        val organizationSlug: String? = null,
         val organizationLogoUrl: String? = null,
         val sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
     )

--- a/sdk/src/main/java/com/stytch/sdk/b2b/discovery/DiscoveryImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/discovery/DiscoveryImpl.kt
@@ -1,0 +1,78 @@
+package com.stytch.sdk.b2b.discovery
+
+import com.stytch.sdk.b2b.DiscoverOrganizationsResponse
+import com.stytch.sdk.b2b.IntermediateSessionExchangeResponse
+import com.stytch.sdk.b2b.OrganizationCreateResponse
+import com.stytch.sdk.b2b.network.StytchB2BApi
+import com.stytch.sdk.common.StytchDispatchers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+internal class DiscoveryImpl(
+    private val externalScope: CoroutineScope,
+    private val dispatchers: StytchDispatchers,
+    private val api: StytchB2BApi.Discovery,
+) : Discovery {
+    override suspend fun organizations(
+        parameters: Discovery.DiscoverOrganizationsParameters
+    ): DiscoverOrganizationsResponse {
+        return withContext(dispatchers.io) {
+            api.discoverOrganizations(parameters.intermediateSessionToken)
+        }
+    }
+
+    override suspend fun organizations(
+        parameters: Discovery.DiscoverOrganizationsParameters,
+        callback: (DiscoverOrganizationsResponse) -> Unit,
+    ) {
+        externalScope.launch(dispatchers.ui) {
+            val result = organizations(parameters)
+            callback(result)
+        }
+    }
+
+    override suspend fun exchangeSession(
+        parameters: Discovery.SessionExchangeParameters
+    ): IntermediateSessionExchangeResponse {
+        return withContext(dispatchers.io) {
+            api.exchangeSession(
+                intermediateSessionToken = parameters.intermediateSessionToken,
+                organizationId = parameters.organizationId,
+                sessionDurationMinutes = parameters.sessionDurationMinutes
+            )
+        }
+    }
+
+    override suspend fun exchangeSession(
+        parameters: Discovery.SessionExchangeParameters,
+        callback: (IntermediateSessionExchangeResponse) -> Unit,
+    ) {
+        externalScope.launch(dispatchers.ui) {
+            val result = exchangeSession(parameters)
+            callback(result)
+        }
+    }
+
+    override suspend fun create(parameters: Discovery.CreateOrganizationParameters): OrganizationCreateResponse {
+        return withContext(dispatchers.io) {
+            api.createOrganization(
+                intermediateSessionToken = parameters.intermediateSessionToken,
+                organizationName = parameters.organizationName,
+                organizationSlug = parameters.organizationSlug,
+                organizationLogoUrl = parameters.organizationLogoUrl,
+                sessionDurationMinutes = parameters.sessionDurationMinutes
+            )
+        }
+    }
+
+    override suspend fun create(
+        parameters: Discovery.CreateOrganizationParameters,
+        callback: (OrganizationCreateResponse) -> Unit,
+    ) {
+        externalScope.launch(dispatchers.ui) {
+            val result = create(parameters)
+            callback(result)
+        }
+    }
+}

--- a/sdk/src/main/java/com/stytch/sdk/b2b/discovery/DiscoveryImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/discovery/DiscoveryImpl.kt
@@ -22,7 +22,7 @@ internal class DiscoveryImpl(
         }
     }
 
-    override suspend fun organizations(
+    override fun organizations(
         parameters: Discovery.DiscoverOrganizationsParameters,
         callback: (DiscoverOrganizationsResponse) -> Unit,
     ) {
@@ -44,7 +44,7 @@ internal class DiscoveryImpl(
         }
     }
 
-    override suspend fun exchangeSession(
+    override fun exchangeSession(
         parameters: Discovery.SessionExchangeParameters,
         callback: (IntermediateSessionExchangeResponse) -> Unit,
     ) {
@@ -66,7 +66,7 @@ internal class DiscoveryImpl(
         }
     }
 
-    override suspend fun create(
+    override fun create(
         parameters: Discovery.CreateOrganizationParameters,
         callback: (OrganizationCreateResponse) -> Unit,
     ) {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/discovery/DiscoveryImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/discovery/DiscoveryImpl.kt
@@ -14,7 +14,7 @@ internal class DiscoveryImpl(
     private val dispatchers: StytchDispatchers,
     private val api: StytchB2BApi.Discovery,
 ) : Discovery {
-    override suspend fun organizations(
+    override suspend fun listOrganizations(
         parameters: Discovery.DiscoverOrganizationsParameters
     ): DiscoverOrganizationsResponse {
         return withContext(dispatchers.io) {
@@ -22,17 +22,17 @@ internal class DiscoveryImpl(
         }
     }
 
-    override fun organizations(
+    override fun listOrganizations(
         parameters: Discovery.DiscoverOrganizationsParameters,
         callback: (DiscoverOrganizationsResponse) -> Unit,
     ) {
         externalScope.launch(dispatchers.ui) {
-            val result = organizations(parameters)
+            val result = listOrganizations(parameters)
             callback(result)
         }
     }
 
-    override suspend fun exchangeSession(
+    override suspend fun exchangeIntermediateSession(
         parameters: Discovery.SessionExchangeParameters
     ): IntermediateSessionExchangeResponse {
         return withContext(dispatchers.io) {
@@ -44,17 +44,19 @@ internal class DiscoveryImpl(
         }
     }
 
-    override fun exchangeSession(
+    override fun exchangeIntermediateSession(
         parameters: Discovery.SessionExchangeParameters,
         callback: (IntermediateSessionExchangeResponse) -> Unit,
     ) {
         externalScope.launch(dispatchers.ui) {
-            val result = exchangeSession(parameters)
+            val result = exchangeIntermediateSession(parameters)
             callback(result)
         }
     }
 
-    override suspend fun create(parameters: Discovery.CreateOrganizationParameters): OrganizationCreateResponse {
+    override suspend fun createOrganization(
+        parameters: Discovery.CreateOrganizationParameters
+    ): OrganizationCreateResponse {
         return withContext(dispatchers.io) {
             api.createOrganization(
                 intermediateSessionToken = parameters.intermediateSessionToken,
@@ -66,12 +68,12 @@ internal class DiscoveryImpl(
         }
     }
 
-    override fun create(
+    override fun createOrganization(
         parameters: Discovery.CreateOrganizationParameters,
         callback: (OrganizationCreateResponse) -> Unit,
     ) {
         externalScope.launch(dispatchers.ui) {
-            val result = create(parameters)
+            val result = createOrganization(parameters)
             callback(result)
         }
     }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/discovery/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/discovery/README.md
@@ -1,0 +1,14 @@
+# Package com.stytch.sdk.b2b.discovery
+The [Discovery](Discovery.kt) interface provides methods for discovering a member's available organizations, creating organizations, and exchanging sessions between organizations.
+
+The Discovery product lets End Users discover and log in to Organizations they are a Member of, invited to, or eligible to join.
+
+Unlike our other B2B products, Discovery allows End Users to authenticate without specifying an Organization in advance. This is done via a Discovery Magic Link flow. After an End User is authenticated, an Intermediate Session is returned along with a list of associated Organizations.
+
+The End User can then authenticate to the desired Organization by passing the Intermediate Session and organization_id. End users can even create a new Organization instead of joining or logging in to an existing one.
+
+Call the `StytchB2BClient.discovery.organizations()` method to find a member's available organizations.
+
+Call the `StytchB2BClient.discovery.exchangeSession()` method to exchange a session between organizations.
+
+Call the `StytchB2BClient.discovery.create()` method to create a new organization.

--- a/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
@@ -63,6 +63,33 @@ public interface B2BMagicLinks {
     )
 
     /**
+     * A data class used for wrapping parameters used for authenticating a discovery magic link
+     * @property token the discovery magic links token
+     */
+    public data class DiscoveryAuthenticateParameters(
+        val token: String,
+    )
+
+    /**
+     * Authenticate a Member with a Discovery Magic Link. This endpoint requires a Magic Link token that is not
+     * expired or previously used.
+     * @param parameters required to authenticate
+     * @return [DiscoveryEMLAuthResponse]
+     */
+    public suspend fun discoveryAuthenticate(parameters: DiscoveryAuthenticateParameters): DiscoveryEMLAuthResponse
+
+    /**
+     * Authenticate a Member with a Discovery Magic Link. This endpoint requires a Magic Link token that is not
+     * expired or previously used.
+     * @param parameters required to authenticate
+     * @param callback a callback that receives a [DiscoveryEMLAuthResponse]
+     */
+    public fun discoveryAuthenticate(
+        parameters: DiscoveryAuthenticateParameters,
+        callback: (DiscoveryEMLAuthResponse) -> Unit
+    )
+
+    /**
      * Provides all possible ways to call EmailMagicLinks endpoints
      */
     public interface EmailMagicLinks {
@@ -108,17 +135,7 @@ public interface B2BMagicLinks {
             parameters: Parameters,
             callback: (response: BaseResponse) -> Unit,
         )
-    }
 
-    /**
-     * Public variable that exposes an instance of [DiscoveryMagicLinks]
-     */
-    public val discovery: DiscoveryMagicLinks
-
-    /**
-     * Provides all possible ways to call Discovery Magic Links endpoints
-     */
-    public interface DiscoveryMagicLinks {
         /**
          * A data class used for wrapping paramaters used for sending a discovery magic link
          * @property emailAddress is the account identifier for the account in the form of an Email address where you
@@ -128,7 +145,7 @@ public interface B2BMagicLinks {
          * template. The template must be a template using our built-in customizations or a custom HTML email for
          * Magic links - Login.
          */
-        public data class SendParameters(
+        public data class DiscoverySendParameters(
             val emailAddress: String,
             val discoveryRedirectUrl: String? = null,
             val loginTemplateId: String? = null,
@@ -141,7 +158,7 @@ public interface B2BMagicLinks {
          * @param parameters required to send a discovery magic link
          * @return [BaseResponse]
          */
-        public suspend fun send(parameters: SendParameters): BaseResponse
+        public suspend fun discoverySend(parameters: DiscoverySendParameters): BaseResponse
 
         /**
          * Send an invite email to a new Member to join an Organization. The Member will be created with an invited
@@ -150,30 +167,6 @@ public interface B2BMagicLinks {
          * @param parameters required to send a discovery magic link
          * @param callback a callback that receives a [BaseResponse]
          */
-        public fun send(parameters: SendParameters, callback: (BaseResponse) -> Unit)
-
-        /**
-         * A data class used for wrapping parameters used for authenticating a discovery magic link
-         * @property token the discovery magic links token
-         */
-        public data class AuthenticateParameters(
-            val token: String,
-        )
-
-        /**
-         * Authenticate a Member with a Discovery Magic Link. This endpoint requires a Magic Link token that is not
-         * expired or previously used.
-         * @param parameters required to authenticate
-         * @return [DiscoveryEMLAuthResponse]
-         */
-        public suspend fun authenticate(parameters: AuthenticateParameters): DiscoveryEMLAuthResponse
-
-        /**
-         * Authenticate a Member with a Discovery Magic Link. This endpoint requires a Magic Link token that is not
-         * expired or previously used.
-         * @param parameters required to authenticate
-         * @param callback a callback that receives a [DiscoveryEMLAuthResponse]
-         */
-        public fun authenticate(parameters: AuthenticateParameters, callback: (DiscoveryEMLAuthResponse) -> Unit)
+        public fun discoverySend(parameters: DiscoverySendParameters, callback: (BaseResponse) -> Unit)
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinks.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.b2b.magicLinks
 
 import com.stytch.sdk.b2b.AuthResponse
+import com.stytch.sdk.b2b.DiscoveryEMLAuthResponse
 import com.stytch.sdk.common.BaseResponse
 import com.stytch.sdk.common.Constants
 
@@ -17,6 +18,11 @@ import com.stytch.sdk.common.Constants
  *
  * If you are not using our deeplink handler, you must parse out the token from the deeplink yourself and pass it to
  * the StytchB2BClient.magicLinks.authenticate() method.
+ *
+ * Call the `StytchB2BClient.magicLinks.discovery.send()` method to send an invite email to a new Member to join an
+ * Organization.
+ *
+ * Call the `StytchB2BClient.magicLinks.discovery.authenticate()` method to authenticate a Member with a Magic Link.
  */
 public interface B2BMagicLinks {
 
@@ -71,8 +77,8 @@ public interface B2BMagicLinks {
          * @property loginTemplateId Use a custom template for login emails. By default, it will use your default email
          * template. The template must be a template using our built-in customizations or a custom HTML email for
          * Magic links - Login.
-         * @property signupTemplateId Use a custom template for sign-up emails. By default, it will use your default email
-         * template. The template must be a template using our built-in customizations or a custom HTML email for
+         * @property signupTemplateId Use a custom template for sign-up emails. By default, it will use your default
+         * email template. The template must be a template using our built-in customizations or a custom HTML email for
          * Magic links - Sign-up.
          */
         public data class Parameters(
@@ -102,5 +108,72 @@ public interface B2BMagicLinks {
             parameters: Parameters,
             callback: (response: BaseResponse) -> Unit,
         )
+    }
+
+    /**
+     * Public variable that exposes an instance of [DiscoveryMagicLinks]
+     */
+    public val discovery: DiscoveryMagicLinks
+
+    /**
+     * Provides all possible ways to call Discovery Magic Links endpoints
+     */
+    public interface DiscoveryMagicLinks {
+        /**
+         * A data class used for wrapping paramaters used for sending a discovery magic link
+         * @property emailAddress is the account identifier for the account in the form of an Email address where you
+         * wish to receive a magic link to authenticate
+         * @property discoveryRedirectUrl is the url where you should be redirected for organization discovery
+         * @property loginTemplateId Use a custom template for login emails. By default, it will use your default email
+         * template. The template must be a template using our built-in customizations or a custom HTML email for
+         * Magic links - Login.
+         */
+        public data class SendParameters(
+            val emailAddress: String,
+            val discoveryRedirectUrl: String? = null,
+            val loginTemplateId: String? = null,
+        )
+
+        /**
+         * Send an invite email to a new Member to join an Organization. The Member will be created with an invited
+         * status until they successfully authenticate. Sending invites to pending Members will update their status to
+         * invited. Sending invites to already active Members will return an error.
+         * @param parameters required to send a discovery magic link
+         * @return [BaseResponse]
+         */
+        public suspend fun send(parameters: SendParameters): BaseResponse
+
+        /**
+         * Send an invite email to a new Member to join an Organization. The Member will be created with an invited
+         * status until they successfully authenticate. Sending invites to pending Members will update their status to
+         * invited. Sending invites to already active Members will return an error.
+         * @param parameters required to send a discovery magic link
+         * @param callback a callback that receives a [BaseResponse]
+         */
+        public fun send(parameters: SendParameters, callback: (BaseResponse) -> Unit)
+
+        /**
+         * A data class used for wrapping parameters used for authenticating a discovery magic link
+         * @property token the discovery magic links token
+         */
+        public data class AuthenticateParameters(
+            val token: String,
+        )
+
+        /**
+         * Authenticate a Member with a Discovery Magic Link. This endpoint requires a Magic Link token that is not
+         * expired or previously used.
+         * @param parameters required to authenticate
+         * @return [DiscoveryEMLAuthResponse]
+         */
+        public suspend fun authenticate(parameters: AuthenticateParameters): DiscoveryEMLAuthResponse
+
+        /**
+         * Authenticate a Member with a Discovery Magic Link. This endpoint requires a Magic Link token that is not
+         * expired or previously used.
+         * @param parameters required to authenticate
+         * @param callback a callback that receives a [DiscoveryEMLAuthResponse]
+         */
+        public fun authenticate(parameters: AuthenticateParameters, callback: (DiscoveryEMLAuthResponse) -> Unit)
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/README.md
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/magicLinks/README.md
@@ -6,3 +6,7 @@ Call the `StytchB2BClient.magicLinks.email.loginOrSignup()` method to request an
 If you have connected your deeplink handler with `StytchB2BClient`, the resulting magic link should be detected by your application and automatically authenticated (via the `StytchB2BClient.handle()` method). See the instructions in the [top-level README](/README.md) for information on handling deeplink intents.
 
 If you are not using our deeplink handler, you must parse out the token from the deeplink yourself and pass it to the `StytchB2BClient.magicLinks.authenticate()` method.
+
+Call the `StytchB2BClient.magicLinks.discovery.send()` method to send an invite email to a new Member to join an Organization.
+
+Call the `StytchB2BClient.magicLinks.discovery.authenticate()` method to authenticate a Member with a Magic Link.

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -7,6 +7,7 @@ import com.stytch.sdk.b2b.network.models.B2BEMLAuthenticateData
 import com.stytch.sdk.b2b.network.models.B2BRequests
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
+import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.IB2BAuthData
 import com.stytch.sdk.b2b.network.models.IntermediateSessionExchangeResponseData
 import com.stytch.sdk.b2b.network.models.MemberResponseData
@@ -111,6 +112,36 @@ internal object StytchB2BApi {
                         token = token,
                         codeVerifier = codeVerifier,
                         sessionDurationMinutes = sessionDurationMinutes.toInt()
+                    )
+                )
+            }
+        }
+
+        object Discovery {
+            suspend fun send(
+                email: String,
+                discoveryRedirectUrl: String?,
+                codeChallenge: String,
+                loginTemplateId: String?,
+            ): StytchResult<BasicData> = safeB2BApiCall {
+                apiService.sendDiscoveryMagicLink(
+                    B2BRequests.MagicLinks.Discovery.SendRequest(
+                        email = email,
+                        discoveryRedirectUrl = discoveryRedirectUrl,
+                        codeChallenge = codeChallenge,
+                        loginTemplateId = loginTemplateId
+                    )
+                )
+            }
+
+            suspend fun authenticate(
+                token: String,
+                codeVerifier: String,
+            ): StytchResult<DiscoveryAuthenticateResponseData> = safeB2BApiCall {
+                apiService.authenticateDiscoveryMagicLink(
+                    B2BRequests.MagicLinks.Discovery.AuthenticateRequest(
+                        token = token,
+                        codeVerifier = codeVerifier
                     )
                 )
             }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -5,9 +5,9 @@ import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.network.models.B2BAuthData
 import com.stytch.sdk.b2b.network.models.B2BEMLAuthenticateData
 import com.stytch.sdk.b2b.network.models.B2BRequests
-import com.stytch.sdk.b2b.network.models.EmailResetResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
+import com.stytch.sdk.b2b.network.models.EmailResetResponseData
 import com.stytch.sdk.b2b.network.models.IB2BAuthData
 import com.stytch.sdk.b2b.network.models.IntermediateSessionExchangeResponseData
 import com.stytch.sdk.b2b.network.models.MemberResponseData

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -272,8 +272,8 @@ internal object StytchB2BApi {
         suspend fun createOrganization(
             intermediateSessionToken: String,
             sessionDurationMinutes: UInt,
-            organizationName: String,
-            organizationSlug: String,
+            organizationName: String?,
+            organizationSlug: String?,
             organizationLogoUrl: String?,
         ): StytchResult<OrganizationCreateResponseData> = safeB2BApiCall {
             apiService.createOrganization(

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -6,8 +6,11 @@ import com.stytch.sdk.b2b.network.models.B2BAuthData
 import com.stytch.sdk.b2b.network.models.B2BEMLAuthenticateData
 import com.stytch.sdk.b2b.network.models.B2BRequests
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
+import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.IB2BAuthData
+import com.stytch.sdk.b2b.network.models.IntermediateSessionExchangeResponseData
 import com.stytch.sdk.b2b.network.models.MemberResponseData
+import com.stytch.sdk.b2b.network.models.OrganizationCreateResponseData
 import com.stytch.sdk.b2b.network.models.OrganizationResponseData
 import com.stytch.sdk.b2b.network.models.PasswordsAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.SessionResetResponseData
@@ -116,7 +119,7 @@ internal object StytchB2BApi {
 
     internal object Sessions {
         suspend fun authenticate(
-            sessionDurationMinutes: UInt? = null
+            sessionDurationMinutes: UInt?
         ): StytchResult<IB2BAuthData> = safeB2BApiCall {
             apiService.authenticateSessions(
                 CommonRequests.Sessions.AuthenticateRequest(
@@ -236,6 +239,50 @@ internal object StytchB2BApi {
                 B2BRequests.Passwords.StrengthCheckRequest(
                     email = email,
                     password = password,
+                )
+            )
+        }
+    }
+
+    internal object Discovery {
+        suspend fun discoverOrganizations(
+            intermediateSessionToken: String?,
+        ): StytchResult<DiscoveredOrganizationsResponseData> = safeB2BApiCall {
+            apiService.discoverOrganizations(
+                B2BRequests.Discovery.MembershipsRequest(
+                    intermediateSessionToken = intermediateSessionToken
+                )
+            )
+        }
+
+        suspend fun exchangeSession(
+            intermediateSessionToken: String,
+            organizationId: String,
+            sessionDurationMinutes: UInt,
+        ): StytchResult<IntermediateSessionExchangeResponseData> = safeB2BApiCall {
+            apiService.intermediateSessionExchange(
+                B2BRequests.Discovery.SessionExchangeRequest(
+                    intermediateSessionToken = intermediateSessionToken,
+                    organizationId = organizationId,
+                    sessionDurationMinutes = sessionDurationMinutes.toInt()
+                )
+            )
+        }
+
+        suspend fun createOrganization(
+            intermediateSessionToken: String,
+            sessionDurationMinutes: UInt,
+            organizationName: String,
+            organizationSlug: String,
+            organizationLogoUrl: String?,
+        ): StytchResult<OrganizationCreateResponseData> = safeB2BApiCall {
+            apiService.createOrganization(
+                B2BRequests.Discovery.CreateRequest(
+                    intermediateSessionToken = intermediateSessionToken,
+                    sessionDurationMinutes = sessionDurationMinutes.toInt(),
+                    organizationName = organizationName,
+                    organizationSlug = organizationSlug,
+                    organizationLogoUrl = organizationLogoUrl
                 )
             )
         }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -10,16 +10,26 @@ import retrofit2.http.GET
 import retrofit2.http.POST
 
 internal interface StytchB2BApiService : ApiService {
-    //region MagicLinks
+    //region Magic Links
     @POST("b2b/magic_links/email/login_or_signup")
     suspend fun loginOrSignupByEmail(
         @Body request: B2BRequests.MagicLinks.Email.LoginOrSignupRequest
-    ): CommonResponses.MagicLinks.Email.LoginOrCreateUserResponse
+    ): CommonResponses.BasicResponse
 
     @POST("b2b/magic_links/authenticate")
     suspend fun authenticate(
         @Body request: B2BRequests.MagicLinks.AuthenticateRequest
     ): B2BResponses.MagicLinks.AuthenticateResponse
+
+    @POST("b2b/magic_links/email/discovery/send")
+    suspend fun sendDiscoveryMagicLink(
+        @Body request: B2BRequests.MagicLinks.Discovery.SendRequest
+    ): CommonResponses.BasicResponse
+
+    @POST("b2b/magic_links/discovery/authenticate")
+    suspend fun authenticateDiscoveryMagicLink(
+        @Body request: B2BRequests.MagicLinks.Discovery.AuthenticateRequest
+    ): B2BResponses.MagicLinks.DiscoveryAuthenticateResponse
     //endregion Magic Links
 
     //region Sessions

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApiService.kt
@@ -71,4 +71,21 @@ internal interface StytchB2BApiService : ApiService {
         @Body request: B2BRequests.Passwords.StrengthCheckRequest
     ): B2BResponses.Passwords.StrengthCheckResponse
     //endregion Passwords
+
+    //region Discovery
+    @POST("b2b/discovery/organizations")
+    suspend fun discoverOrganizations(
+        @Body request: B2BRequests.Discovery.MembershipsRequest
+    ): B2BResponses.Discovery.DiscoverOrganizationsResponse
+
+    @POST("b2b/discovery/intermediate_sessions/exchange")
+    suspend fun intermediateSessionExchange(
+        @Body request: B2BRequests.Discovery.SessionExchangeRequest
+    ): B2BResponses.Discovery.SessionExchangeResponse
+
+    @POST("b2b/discovery/organizations/create")
+    suspend fun createOrganization(
+        @Body request: B2BRequests.Discovery.CreateRequest
+    ): B2BResponses.Discovery.CreateOrganizationResponse
+    //endregion Discovery
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -128,11 +128,11 @@ internal object B2BRequests {
             @Json(name = "session_duration_minutes")
             val sessionDurationMinutes: Int,
             @Json(name = "organization_name")
-            val organizationName: String,
+            val organizationName: String?,
             @Json(name = "organization_slug")
-            val organizationSlug: String,
+            val organizationSlug: String?,
             @Json(name = "organization_logo_url")
-            val organizationLogoUrl: String? = null,
+            val organizationLogoUrl: String?,
         )
     }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -104,4 +104,35 @@ internal object B2BRequests {
             val password: String,
         )
     }
+    object Discovery {
+        @JsonClass(generateAdapter = true)
+        data class MembershipsRequest(
+            @Json(name = "intermediate_session_token")
+            val intermediateSessionToken: String? = null,
+        )
+
+        @JsonClass(generateAdapter = true)
+        data class SessionExchangeRequest(
+            @Json(name = "intermediate_session_token")
+            val intermediateSessionToken: String,
+            @Json(name = "organization_id")
+            val organizationId: String,
+            @Json(name = "session_duration_minutes")
+            val sessionDurationMinutes: Int,
+        )
+
+        @JsonClass(generateAdapter = true)
+        data class CreateRequest(
+            @Json(name = "intermediate_session_token")
+            val intermediateSessionToken: String,
+            @Json(name = "session_duration_minutes")
+            val sessionDurationMinutes: Int,
+            @Json(name = "organization_name")
+            val organizationName: String,
+            @Json(name = "organization_slug")
+            val organizationSlug: String,
+            @Json(name = "organization_logo_url")
+            val organizationLogoUrl: String? = null,
+        )
+    }
 }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -25,6 +25,28 @@ internal object B2BRequests {
             )
         }
 
+        object Discovery {
+            @JsonClass(generateAdapter = true)
+            data class SendRequest(
+                @Json(name = "email_address")
+                val email: String,
+                @Json(name = "discovery_redirect_url")
+                val discoveryRedirectUrl: String? = null,
+                @Json(name = "pkce_code_challenge")
+                val codeChallenge: String,
+                @Json(name = "login_template_id")
+                val loginTemplateId: String? = null,
+            )
+
+            @JsonClass(generateAdapter = true)
+            data class AuthenticateRequest(
+                @Json(name = "discovery_magic_links_token")
+                val token: String,
+                @Json(name = "pkce_code_verifier")
+                val codeVerifier: String,
+            )
+        }
+
         @JsonClass(generateAdapter = true)
         data class AuthenticateRequest(
             @Json(name = "magic_links_token")

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -223,3 +223,58 @@ public data class StrengthCheckResponseData(
         val missingCharacters: Int,
     )
 }
+
+public data class DiscoveredOrganizationsResponseData(
+    @Json(name = "email_address")
+    val emailAddress: String,
+    @Json(name = "discovered_organizations")
+    val discoveredOrganizations: List<DiscoveredOrganization>
+)
+
+@JsonClass(generateAdapter = true)
+public data class DiscoveredOrganization(
+    val organization: Organization,
+    val membership: Membership,
+    @Json(name = "member_authenticated")
+    val memberAuthenticated: Boolean,
+)
+
+@JsonClass(generateAdapter = true)
+public data class Membership(
+    val type: String,
+    val details: MembershipDetails?,
+    val member: MemberData?,
+)
+
+@JsonClass(generateAdapter = true)
+public data class MembershipDetails(
+    val domain: String,
+)
+
+@JsonClass(generateAdapter = true)
+public data class IntermediateSessionExchangeResponseData(
+    @Json(name = "status_code")
+    val statusCode: Int,
+    @Json(name = "request_id")
+    val requestId: String,
+    @Json(name = "member_session")
+    val memberSession: B2BSessionData,
+    @Json(name = "session_jwt")
+    val sessionJwt: String,
+    @Json(name = "session_token")
+    val sessionToken: String,
+)
+
+@JsonClass(generateAdapter = true)
+public data class OrganizationCreateResponseData(
+    @Json(name = "status_code")
+    val statusCode: Int,
+    @Json(name = "request_id")
+    val requestId: String,
+    @Json(name = "member_session")
+    val memberSession: B2BSessionData,
+    @Json(name = "session_jwt")
+    val sessionJwt: String,
+    @Json(name = "session_token")
+    val sessionToken: String,
+)

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -278,3 +278,13 @@ public data class OrganizationCreateResponseData(
     @Json(name = "session_token")
     val sessionToken: String,
 )
+
+@JsonClass(generateAdapter = true)
+public data class DiscoveryAuthenticateResponseData(
+    @Json(name = "intermediate_session_token")
+    val intermediateSessionToken: String,
+    @Json(name = "email_address")
+    val emailAddress: String,
+    @Json(name = "discovered_organizations")
+    val discoveredOrganizations: List<DiscoveredOrganization>
+)

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -224,6 +224,7 @@ public data class StrengthCheckResponseData(
     )
 }
 
+@JsonClass(generateAdapter = true)
 public data class DiscoveredOrganizationsResponseData(
     @Json(name = "email_address")
     val emailAddress: String,

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -8,6 +8,11 @@ internal object B2BResponses {
     object MagicLinks {
         @JsonClass(generateAdapter = true)
         class AuthenticateResponse(data: B2BEMLAuthenticateData) : StytchDataResponse<B2BEMLAuthenticateData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class DiscoveryAuthenticateResponse(
+            data: DiscoveryAuthenticateResponseData
+        ) : StytchDataResponse<DiscoveryAuthenticateResponseData>(data)
     }
 
     object Sessions {

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponses.kt
@@ -50,4 +50,21 @@ internal object B2BResponses {
             data: StrengthCheckResponseData
         ) : StytchDataResponse<StrengthCheckResponseData>(data)
     }
+
+    object Discovery {
+        @JsonClass(generateAdapter = true)
+        class DiscoverOrganizationsResponse(
+            data: DiscoveredOrganizationsResponseData
+        ) : StytchDataResponse<DiscoveredOrganizationsResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class SessionExchangeResponse(
+            data: IntermediateSessionExchangeResponseData
+        ) : StytchDataResponse<IntermediateSessionExchangeResponseData>(data)
+
+        @JsonClass(generateAdapter = true)
+        class CreateOrganizationResponse(
+            data: OrganizationCreateResponseData
+        ) : StytchDataResponse<OrganizationCreateResponseData>(data)
+    }
 }

--- a/sdk/src/main/java/com/stytch/sdk/common/DeeplinkHandledStatus.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/DeeplinkHandledStatus.kt
@@ -8,7 +8,7 @@ public sealed interface DeeplinkHandledStatus {
      * Indicates that a deeplink was successfully parsed from the deeplink.
      * @property response A [StytchResult] representing either the authenticated response or an error.
      */
-    public data class Handled(val response: StytchResult<Any>) : DeeplinkHandledStatus
+    public data class Handled(val response: DeeplinkResponse) : DeeplinkHandledStatus
 
     /**
      * Indicates that a deeplink was not handled by the Stytch client, either because a token could not be parsed from

--- a/sdk/src/main/java/com/stytch/sdk/common/DeeplinkHandledStatus.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/DeeplinkHandledStatus.kt
@@ -1,7 +1,5 @@
 package com.stytch.sdk.common
 
-import com.stytch.sdk.common.network.models.CommonAuthenticationData
-
 /**
  * A class representing the three states of a deeplink handled by StytchClient.handle() / StytchB2BClient.handle()
  */
@@ -10,7 +8,7 @@ public sealed interface DeeplinkHandledStatus {
      * Indicates that a deeplink was successfully parsed from the deeplink.
      * @property response A [StytchResult] representing either the authenticated response or an error.
      */
-    public data class Handled(val response: StytchResult<CommonAuthenticationData>) : DeeplinkHandledStatus
+    public data class Handled(val response: StytchResult<Any>) : DeeplinkHandledStatus
 
     /**
      * Indicates that a deeplink was not handled by the Stytch client, either because a token could not be parsed from

--- a/sdk/src/main/java/com/stytch/sdk/common/DeeplinkResponse.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/DeeplinkResponse.kt
@@ -1,0 +1,13 @@
+package com.stytch.sdk.common
+
+import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
+import com.stytch.sdk.common.network.models.CommonAuthenticationData
+
+public sealed class DeeplinkResponse(public open val result: StytchResult<Any>) {
+    public data class Auth(
+        override val result: StytchResult<CommonAuthenticationData>
+    ) : DeeplinkResponse(result)
+    public data class Discovery(
+        override val result: StytchResult<DiscoveryAuthenticateResponseData>
+    ) : DeeplinkResponse(result)
+}

--- a/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponses.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/models/CommonResponses.kt
@@ -4,13 +4,6 @@ import com.squareup.moshi.JsonClass
 import com.stytch.sdk.common.network.StytchDataResponse
 
 internal object CommonResponses {
-    object MagicLinks {
-        object Email {
-            @JsonClass(generateAdapter = true)
-            class LoginOrCreateUserResponse(data: BasicData) : StytchDataResponse<BasicData>(data)
-        }
-    }
-
     object Passwords {
         @JsonClass(generateAdapter = true)
         class PasswordsStrengthCheckResponse(data: StrengthCheckResponse) :

--- a/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/StytchClient.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import com.stytch.sdk.common.Constants
 import com.stytch.sdk.common.DeeplinkHandledStatus
+import com.stytch.sdk.common.DeeplinkResponse
 import com.stytch.sdk.common.StorageHelper
 import com.stytch.sdk.common.StytchDispatchers
 import com.stytch.sdk.common.StytchExceptions
@@ -228,12 +229,16 @@ public object StytchClient {
             when (ConsumerTokenType.fromString(uri.getQueryParameter(Constants.QUERY_TOKEN_TYPE))) {
                 ConsumerTokenType.MAGIC_LINKS -> {
                     DeeplinkHandledStatus.Handled(
-                        magicLinks.authenticate(MagicLinks.AuthParameters(token, sessionDurationMinutes))
+                        DeeplinkResponse.Auth(
+                            magicLinks.authenticate(MagicLinks.AuthParameters(token, sessionDurationMinutes))
+                        )
                     )
                 }
                 ConsumerTokenType.OAUTH -> {
                     DeeplinkHandledStatus.Handled(
-                        oauth.authenticate(OAuth.ThirdParty.AuthenticateParameters(token, sessionDurationMinutes))
+                        DeeplinkResponse.Auth(
+                            oauth.authenticate(OAuth.ThirdParty.AuthenticateParameters(token, sessionDurationMinutes))
+                        )
                     )
                 }
                 ConsumerTokenType.PASSWORD_RESET -> {

--- a/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/consumer/network/StytchApiService.kt
@@ -18,7 +18,7 @@ internal interface StytchApiService : ApiService {
     @POST("magic_links/email/login_or_create")
     suspend fun loginOrCreateUserByEmail(
         @Body request: ConsumerRequests.MagicLinks.Email.LoginOrCreateUserRequest
-    ): CommonResponses.MagicLinks.Email.LoginOrCreateUserResponse
+    ): CommonResponses.BasicResponse
 
     @POST("magic_links/email/send/primary")
     suspend fun sendEmailMagicLinkPrimary(

--- a/sdk/src/test/java/com/stytch/sdk/b2b/B2BTokenTypeTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/B2BTokenTypeTest.kt
@@ -6,6 +6,7 @@ internal class B2BTokenTypeTest {
     @Test
     fun `B2BTokenType fromString returns expected values`() {
         assert(B2BTokenType.fromString("multi_tenant_magic_links") == B2BTokenType.MULTI_TENANT_MAGIC_LINKS)
+        assert(B2BTokenType.fromString("discovery") == B2BTokenType.DISCOVERY)
         assert(B2BTokenType.fromString("something_unexpected") == B2BTokenType.UNKNOWN)
     }
 }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import com.stytch.sdk.b2b.magicLinks.B2BMagicLinks
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.common.DeeplinkHandledStatus
+import com.stytch.sdk.common.DeeplinkResponse
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.StorageHelper
@@ -229,6 +230,21 @@ internal class StytchB2BClientTest {
     }
 
     @Test
+    fun `handle with coroutines delegates to magiclinks when token is DISCOVERY`() {
+        runBlocking {
+            every { StytchB2BApi.isInitialized } returns true
+            val mockUri = mockk<Uri> {
+                every { getQueryParameter(any()) } returns "DISCOVERY"
+            }
+            val mockAuthResponse = mockk<DiscoveryEMLAuthResponse>()
+            coEvery { mockMagicLinks.discoveryAuthenticate(any()) } returns mockAuthResponse
+            val response = StytchB2BClient.handle(mockUri, 30U)
+            coVerify { mockMagicLinks.discoveryAuthenticate(any()) }
+            assert(response == DeeplinkHandledStatus.Handled(DeeplinkResponse.Discovery(mockAuthResponse)))
+        }
+    }
+
+    @Test
     fun `handle with coroutines delegates to magiclinks when token is MAGIC_LINKS`() {
         runBlocking {
             every { StytchB2BApi.isInitialized } returns true
@@ -239,7 +255,7 @@ internal class StytchB2BClientTest {
             coEvery { mockMagicLinks.authenticate(any()) } returns mockAuthResponse
             val response = StytchB2BClient.handle(mockUri, 30U)
             coVerify { mockMagicLinks.authenticate(any()) }
-            assert(response == DeeplinkHandledStatus.Handled(mockAuthResponse))
+            assert(response == DeeplinkHandledStatus.Handled(DeeplinkResponse.Auth(mockAuthResponse)))
         }
     }
 

--- a/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/StytchB2BClientTest.kt
@@ -165,7 +165,7 @@ internal class StytchB2BClientTest {
     }
 
     @Test
-    fun `accessing StytchB2BClient member returns instance of Session when configured`() {
+    fun `accessing StytchB2BClient member returns instance of member when configured`() {
         every { StytchB2BApi.isInitialized } returns true
         StytchB2BClient.member
     }
@@ -180,6 +180,18 @@ internal class StytchB2BClientTest {
     fun `accessing StytchB2BClient passwords returns instance of Session when configured`() {
         every { StytchB2BApi.isInitialized } returns true
         StytchB2BClient.passwords
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `accessing StytchB2BClient discovery throws IllegalStateException when not configured`() {
+        every { StytchB2BApi.isInitialized } returns false
+        StytchB2BClient.discovery
+    }
+
+    @Test
+    fun `accessing StytchB2BClient discovery returns instance of Discovery when configured`() {
+        every { StytchB2BApi.isInitialized } returns true
+        StytchB2BClient.discovery
     }
 
     @Test(expected = IllegalStateException::class)

--- a/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryImplTest.kt
@@ -50,7 +50,7 @@ internal class DiscoveryImplTest {
     @Test
     fun `DiscoveryImpl organizations delegates to api`() = runTest {
         coEvery { mockApi.discoverOrganizations(any()) } returns StytchResult.Success(mockk(relaxed = true))
-        val response = impl.organizations(mockk(relaxed = true))
+        val response = impl.listOrganizations(mockk(relaxed = true))
         assert(response is StytchResult.Success)
         coVerify { mockApi.discoverOrganizations(any()) }
     }
@@ -59,14 +59,14 @@ internal class DiscoveryImplTest {
     fun `DiscoveryImpl organizations with callback calls callback method`() {
         coEvery { mockApi.discoverOrganizations(any()) } returns StytchResult.Success(mockk(relaxed = true))
         val mockCallback = spyk<(DiscoverOrganizationsResponse) -> Unit>()
-        impl.organizations(mockk(relaxed = true), mockCallback)
+        impl.listOrganizations(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 
     @Test
     fun `DiscoveryImpl exchangeSession delegates to api`() = runTest {
         coEvery { mockApi.exchangeSession(any(), any(), any()) } returns StytchResult.Success(mockk(relaxed = true))
-        val response = impl.exchangeSession(mockk(relaxed = true))
+        val response = impl.exchangeIntermediateSession(mockk(relaxed = true))
         assert(response is StytchResult.Success)
         coVerify { mockApi.exchangeSession(any(), any(), any()) }
     }
@@ -75,7 +75,7 @@ internal class DiscoveryImplTest {
     fun `DiscoveryImpl exchangeSession with callback calls callback method`() {
         coEvery { mockApi.exchangeSession(any(), any(), any()) } returns StytchResult.Success(mockk(relaxed = true))
         val mockCallback = spyk<(IntermediateSessionExchangeResponse) -> Unit>()
-        impl.exchangeSession(mockk(relaxed = true), mockCallback)
+        impl.exchangeIntermediateSession(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 
@@ -84,7 +84,7 @@ internal class DiscoveryImplTest {
         coEvery {
             mockApi.createOrganization(any(), any(), any(), any(), any())
         } returns StytchResult.Success(mockk(relaxed = true))
-        val response = impl.create(mockk(relaxed = true))
+        val response = impl.createOrganization(mockk(relaxed = true))
         assert(response is StytchResult.Success)
         coVerify { mockApi.createOrganization(any(), any(), any(), any(), any()) }
     }
@@ -95,7 +95,7 @@ internal class DiscoveryImplTest {
             mockApi.createOrganization(any(), any(), any(), any(), any())
         } returns StytchResult.Success(mockk(relaxed = true))
         val mockCallback = spyk<(OrganizationCreateResponse) -> Unit>()
-        impl.create(mockk(relaxed = true), mockCallback)
+        impl.createOrganization(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryImplTest.kt
@@ -1,0 +1,101 @@
+package com.stytch.sdk.b2b.discovery
+
+import com.stytch.sdk.b2b.DiscoverOrganizationsResponse
+import com.stytch.sdk.b2b.IntermediateSessionExchangeResponse
+import com.stytch.sdk.b2b.OrganizationCreateResponse
+import com.stytch.sdk.b2b.network.StytchB2BApi
+import com.stytch.sdk.common.StytchDispatchers
+import com.stytch.sdk.common.StytchResult
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class DiscoveryImplTest {
+    @MockK
+    private lateinit var mockApi: StytchB2BApi.Discovery
+
+    private lateinit var impl: DiscoveryImpl
+    private val dispatcher = Dispatchers.Unconfined
+
+    @Before
+    fun before() {
+        MockKAnnotations.init(this, true, true)
+        impl = DiscoveryImpl(
+            externalScope = TestScope(),
+            dispatchers = StytchDispatchers(dispatcher, dispatcher),
+            api = mockApi
+        )
+    }
+
+    @After
+    fun after() {
+        unmockkAll()
+        clearAllMocks()
+    }
+
+    @Test
+    fun `DiscoveryImpl organizations delegates to api`() = runTest {
+        coEvery { mockApi.discoverOrganizations(any()) } returns StytchResult.Success(mockk(relaxed = true))
+        val response = impl.organizations(mockk(relaxed = true))
+        assert(response is StytchResult.Success)
+        coVerify { mockApi.discoverOrganizations(any()) }
+    }
+
+    @Test
+    fun `DiscoveryImpl organizations with callback calls callback method`() {
+        coEvery { mockApi.discoverOrganizations(any()) } returns StytchResult.Success(mockk(relaxed = true))
+        val mockCallback = spyk<(DiscoverOrganizationsResponse) -> Unit>()
+        impl.organizations(mockk(relaxed = true), mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `DiscoveryImpl exchangeSession delegates to api`() = runTest {
+        coEvery { mockApi.exchangeSession(any(), any(), any()) } returns StytchResult.Success(mockk(relaxed = true))
+        val response = impl.exchangeSession(mockk(relaxed = true))
+        assert(response is StytchResult.Success)
+        coVerify { mockApi.exchangeSession(any(), any(), any()) }
+    }
+
+    @Test
+    fun `DiscoveryImpl exchangeSession with callback calls callback method`() {
+        coEvery { mockApi.exchangeSession(any(), any(), any()) } returns StytchResult.Success(mockk(relaxed = true))
+        val mockCallback = spyk<(IntermediateSessionExchangeResponse) -> Unit>()
+        impl.exchangeSession(mockk(relaxed = true), mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `DiscoveryImpl create delegates to api`() = runTest {
+        coEvery {
+            mockApi.createOrganization(any(), any(), any(), any(), any())
+        } returns StytchResult.Success(mockk(relaxed = true))
+        val response = impl.create(mockk(relaxed = true))
+        assert(response is StytchResult.Success)
+        coVerify { mockApi.createOrganization(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `DiscoveryImpl create with callback calls callback method`() {
+        coEvery {
+            mockApi.createOrganization(any(), any(), any(), any(), any())
+        } returns StytchResult.Success(mockk(relaxed = true))
+        val mockCallback = spyk<(OrganizationCreateResponse) -> Unit>()
+        impl.create(mockk(relaxed = true), mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryTest.kt
@@ -29,13 +29,11 @@ internal class DiscoveryTest {
     fun `Discovery CreateOrganizationParameters have correct default values`() {
         val params = Discovery.CreateOrganizationParameters(
             intermediateSessionToken = "intermediate-session-token",
-            organizationName = "organization-name",
-            organizationSlug = "organization-slug",
         )
         val expected = Discovery.CreateOrganizationParameters(
             intermediateSessionToken = "intermediate-session-token",
-            organizationName = "organization-name",
-            organizationSlug = "organization-slug",
+            organizationName = null,
+            organizationSlug = null,
             organizationLogoUrl = null,
             sessionDurationMinutes = Constants.DEFAULT_SESSION_TIME_MINUTES,
         )

--- a/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryTest.kt
@@ -1,0 +1,44 @@
+package com.stytch.sdk.b2b.discovery
+
+import com.stytch.sdk.common.Constants
+import org.junit.Test
+
+internal class DiscoveryTest {
+    @Test
+    fun `Discovery DiscoverOrganizationsParameters have correct default values`() {
+        val params = Discovery.DiscoverOrganizationsParameters()
+        val expected = Discovery.DiscoverOrganizationsParameters(intermediateSessionToken = null)
+        assert(params == expected)
+    }
+
+    @Test
+    fun `Discovery SessionExchangeParameters have correct default values`() {
+        val params = Discovery.SessionExchangeParameters(
+            intermediateSessionToken = "intermediate-session-token",
+            organizationId = "organization-id"
+        )
+        val expected = Discovery.SessionExchangeParameters(
+            intermediateSessionToken = "intermediate-session-token",
+            organizationId = "organization-id",
+            sessionDurationMinutes = Constants.DEFAULT_SESSION_TIME_MINUTES
+        )
+        assert(params == expected)
+    }
+
+    @Test
+    fun `Discovery CreateOrganizationParameters have correct default values`() {
+        val params = Discovery.CreateOrganizationParameters(
+            intermediateSessionToken = "intermediate-session-token",
+            organizationName = "organization-name",
+            organizationSlug = "organization-slug",
+        )
+        val expected = Discovery.CreateOrganizationParameters(
+            intermediateSessionToken = "intermediate-session-token",
+            organizationName = "organization-name",
+            organizationSlug = "organization-slug",
+            organizationLogoUrl = null,
+            sessionDurationMinutes = Constants.DEFAULT_SESSION_TIME_MINUTES,
+        )
+        assert(params == expected)
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
@@ -132,9 +132,9 @@ internal class B2BMagicLinksImplTest {
     }
 
     @Test
-    fun `MagicLinksImpl discovery send returns error if generateCodeChallenge fails`() = runTest {
+    fun `MagicLinksImpl email sendDiscovery returns error if generateCodeChallenge fails`() = runTest {
         every { mockStorageHelper.generateHashedCodeChallenge() } throws RuntimeException("Test")
-        val response = impl.discovery.send(mockk(relaxed = true))
+        val response = impl.email.discoverySend(mockk(relaxed = true))
         assert(response is StytchResult.Error)
     }
 
@@ -142,21 +142,21 @@ internal class B2BMagicLinksImplTest {
     fun `MagicLinksImpl discovery send delegates to api`() = runTest {
         every { mockStorageHelper.generateHashedCodeChallenge() } returns Pair("", "")
         coEvery { mockDiscoveryApi.send(any(), any(), any(), any()) } returns mockBaseResponse
-        impl.discovery.send(mockk(relaxed = true))
+        impl.email.discoverySend(mockk(relaxed = true))
         coVerify { mockDiscoveryApi.send(any(), any(), any(), any()) }
     }
 
     @Test
     fun `MagicLinksImpl discovery send with callback calls callback method`() {
         val mockCallback = spyk<(BaseResponse) -> Unit>()
-        impl.discovery.send(mockk(relaxed = true), mockCallback)
+        impl.email.discoverySend(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 
     @Test
     fun `MagicLinksImpl discovery authenticate returns error if retrieveCodeVerifier fails`() = runTest {
         every { mockStorageHelper.retrieveCodeVerifier() } returns null
-        val response = impl.discovery.authenticate(mockk(relaxed = true))
+        val response = impl.discoveryAuthenticate(mockk(relaxed = true))
         assert(response is StytchResult.Error)
     }
 
@@ -164,14 +164,14 @@ internal class B2BMagicLinksImplTest {
     fun `MagicLinksImpl discovery authenticate delegates to api`() = runTest {
         every { mockStorageHelper.retrieveCodeVerifier() } returns ""
         coEvery { mockDiscoveryApi.authenticate(any(), any()) } returns mockk(relaxed = true)
-        impl.discovery.authenticate(mockk(relaxed = true))
+        impl.discoveryAuthenticate(mockk(relaxed = true))
         coVerify { mockDiscoveryApi.authenticate(any(), any()) }
     }
 
     @Test
     fun `MagicLinksImpl discovery authenticate with callback calls callback method`() {
         val mockCallback = spyk<(DiscoveryEMLAuthResponse) -> Unit>()
-        impl.discovery.authenticate(mockk(relaxed = true), mockCallback)
+        impl.discoveryAuthenticate(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksImplTest.kt
@@ -1,6 +1,7 @@
 package com.stytch.sdk.b2b.magicLinks
 
 import com.stytch.sdk.b2b.AuthResponse
+import com.stytch.sdk.b2b.DiscoveryEMLAuthResponse
 import com.stytch.sdk.b2b.extensions.launchSessionUpdater
 import com.stytch.sdk.b2b.network.StytchB2BApi
 import com.stytch.sdk.b2b.network.models.B2BEMLAuthenticateData
@@ -37,7 +38,10 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class B2BMagicLinksImplTest {
     @MockK
-    private lateinit var mockApi: StytchB2BApi.MagicLinks.Email
+    private lateinit var mockEmailApi: StytchB2BApi.MagicLinks.Email
+
+    @MockK
+    private lateinit var mockDiscoveryApi: StytchB2BApi.MagicLinks.Discovery
 
     @MockK
     private lateinit var mockB2BSessionStorage: B2BSessionStorage
@@ -50,7 +54,7 @@ internal class B2BMagicLinksImplTest {
     private val successfulAuthResponse = StytchResult.Success<B2BEMLAuthenticateData>(mockk(relaxed = true))
     private val authParameters = mockk<B2BMagicLinks.AuthParameters>(relaxed = true)
     private val emailMagicLinkParameters = mockk<B2BMagicLinks.EmailMagicLinks.Parameters>(relaxed = true)
-    private val successfulLoginOrCreateResponse = mockk<BaseResponse>()
+    private val mockBaseResponse = mockk<BaseResponse>()
 
     @Before
     fun before() {
@@ -68,7 +72,8 @@ internal class B2BMagicLinksImplTest {
             dispatchers = StytchDispatchers(dispatcher, dispatcher),
             sessionStorage = mockB2BSessionStorage,
             storageHelper = mockStorageHelper,
-            api = mockApi
+            emailApi = mockEmailApi,
+            discoveryApi = mockDiscoveryApi,
         )
     }
 
@@ -88,10 +93,10 @@ internal class B2BMagicLinksImplTest {
     @Test
     fun `MagicLinksImpl authenticate delegates to api`() = runTest {
         every { mockStorageHelper.retrieveCodeVerifier() } returns ""
-        coEvery { mockApi.authenticate(any(), any(), any()) } returns successfulAuthResponse
+        coEvery { mockEmailApi.authenticate(any(), any(), any()) } returns successfulAuthResponse
         val response = impl.authenticate(authParameters)
         assert(response is StytchResult.Success)
-        coVerify { mockApi.authenticate(any(), any(), any()) }
+        coVerify { mockEmailApi.authenticate(any(), any(), any()) }
         verify { successfulAuthResponse.launchSessionUpdater(any(), any()) }
     }
 
@@ -113,16 +118,60 @@ internal class B2BMagicLinksImplTest {
     fun `MagicLinksImpl email loginOrCreate delegates to api`() = runTest {
         every { mockStorageHelper.generateHashedCodeChallenge() } returns Pair("", "")
         coEvery {
-            mockApi.loginOrSignupByEmail(any(), any(), any(), any(), any(), any(), any())
-        } returns successfulLoginOrCreateResponse
+            mockEmailApi.loginOrSignupByEmail(any(), any(), any(), any(), any(), any(), any())
+        } returns mockBaseResponse
         impl.email.loginOrSignup(emailMagicLinkParameters)
-        coVerify { mockApi.loginOrSignupByEmail(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify { mockEmailApi.loginOrSignupByEmail(any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `MagicLinksImpl email loginOrCreate with callback calls callback method`() {
         val mockCallback = spyk<(BaseResponse) -> Unit>()
         impl.email.loginOrSignup(emailMagicLinkParameters, mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `MagicLinksImpl discovery send returns error if generateCodeChallenge fails`() = runTest {
+        every { mockStorageHelper.generateHashedCodeChallenge() } throws RuntimeException("Test")
+        val response = impl.discovery.send(mockk(relaxed = true))
+        assert(response is StytchResult.Error)
+    }
+
+    @Test
+    fun `MagicLinksImpl discovery send delegates to api`() = runTest {
+        every { mockStorageHelper.generateHashedCodeChallenge() } returns Pair("", "")
+        coEvery { mockDiscoveryApi.send(any(), any(), any(), any()) } returns mockBaseResponse
+        impl.discovery.send(mockk(relaxed = true))
+        coVerify { mockDiscoveryApi.send(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `MagicLinksImpl discovery send with callback calls callback method`() {
+        val mockCallback = spyk<(BaseResponse) -> Unit>()
+        impl.discovery.send(mockk(relaxed = true), mockCallback)
+        verify { mockCallback.invoke(any()) }
+    }
+
+    @Test
+    fun `MagicLinksImpl discovery authenticate returns error if retrieveCodeVerifier fails`() = runTest {
+        every { mockStorageHelper.retrieveCodeVerifier() } returns null
+        val response = impl.discovery.authenticate(mockk(relaxed = true))
+        assert(response is StytchResult.Error)
+    }
+
+    @Test
+    fun `MagicLinksImpl discovery authenticate delegates to api`() = runTest {
+        every { mockStorageHelper.retrieveCodeVerifier() } returns ""
+        coEvery { mockDiscoveryApi.authenticate(any(), any()) } returns mockk(relaxed = true)
+        impl.discovery.authenticate(mockk(relaxed = true))
+        coVerify { mockDiscoveryApi.authenticate(any(), any()) }
+    }
+
+    @Test
+    fun `MagicLinksImpl discovery authenticate with callback calls callback method`() {
+        val mockCallback = spyk<(DiscoveryEMLAuthResponse) -> Unit>()
+        impl.discovery.authenticate(mockk(relaxed = true), mockCallback)
         verify { mockCallback.invoke(any()) }
     }
 }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksTest.kt
@@ -22,10 +22,10 @@ internal class B2BMagicLinksTest {
 
     @Test
     fun `MagicLinks Discovery Send parameters have correct default values`() {
-        val params = B2BMagicLinks.DiscoveryMagicLinks.SendParameters(
+        val params = B2BMagicLinks.EmailMagicLinks.DiscoverySendParameters(
             emailAddress = "",
         )
-        val expected = B2BMagicLinks.DiscoveryMagicLinks.SendParameters(
+        val expected = B2BMagicLinks.EmailMagicLinks.DiscoverySendParameters(
             emailAddress = "",
             discoveryRedirectUrl = null,
             loginTemplateId = null,

--- a/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/magicLinks/B2BMagicLinksTest.kt
@@ -19,4 +19,17 @@ internal class B2BMagicLinksTest {
         )
         assert(params == expected)
     }
+
+    @Test
+    fun `MagicLinks Discovery Send parameters have correct default values`() {
+        val params = B2BMagicLinks.DiscoveryMagicLinks.SendParameters(
+            emailAddress = "",
+        )
+        val expected = B2BMagicLinks.DiscoveryMagicLinks.SendParameters(
+            emailAddress = "",
+            discoveryRedirectUrl = null,
+            loginTemplateId = null,
+        )
+        assert(params == expected)
+    }
 }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -93,6 +93,48 @@ internal class StytchB2BApiServiceTest {
         }
     }
 
+    @Test
+    fun `check magic links discovery send request`() {
+        runBlocking {
+            val parameters = B2BRequests.MagicLinks.Discovery.SendRequest(
+                email = "email@address.com",
+                discoveryRedirectUrl = LOGIN_MAGIC_LINK,
+                codeChallenge = "code-challenge",
+                loginTemplateId = "login-template-id"
+            )
+            requestIgnoringResponseException {
+                apiService.sendDiscoveryMagicLink(parameters)
+            }.verifyPost(
+                expectedPath = "/b2b/magic_links/email/discovery/send",
+                expectedBody = mapOf(
+                    "email_address" to parameters.email,
+                    "discovery_redirect_url" to parameters.discoveryRedirectUrl,
+                    "pkce_code_challenge" to parameters.codeChallenge,
+                    "login_template_id" to parameters.loginTemplateId,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `check magic links discovery authenticate request`() {
+        runBlocking {
+            val parameters = B2BRequests.MagicLinks.Discovery.AuthenticateRequest(
+                token = "token",
+                codeVerifier = "123",
+            )
+            requestIgnoringResponseException {
+                apiService.authenticateDiscoveryMagicLink(parameters)
+            }.verifyPost(
+                expectedPath = "/b2b/magic_links/discovery/authenticate",
+                expectedBody = mapOf(
+                    "discovery_magic_links_token" to parameters.token,
+                    "pkce_code_verifier" to parameters.codeVerifier,
+                )
+            )
+        }
+    }
+
     // endregion MagicLinks
 
     // region Sessions

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -144,7 +144,6 @@ internal class StytchB2BApiServiceTest {
     // endregion Organizations
 
     //region Passwords
-
     @Test
     fun `check Passwords authenticatePassword request`() {
         runBlocking {
@@ -283,6 +282,71 @@ internal class StytchB2BApiServiceTest {
         }
     }
     //endregion Passwords
+
+    //region Discovery
+    @Test
+    fun `check Discovery discoverOrganizations request`() {
+        runBlocking {
+            val parameters = B2BRequests.Discovery.MembershipsRequest(
+                intermediateSessionToken = "intermediate-session-token"
+            )
+            requestIgnoringResponseException {
+                apiService.discoverOrganizations(parameters)
+            }.verifyPost(
+                expectedPath = "/b2b/discovery/organizations",
+                expectedBody = mapOf(
+                    "intermediate_session_token" to parameters.intermediateSessionToken
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `check Discovery intermediateSessionExchange request`() {
+        runBlocking {
+            val parameters = B2BRequests.Discovery.SessionExchangeRequest(
+                intermediateSessionToken = "intermediate-session-token",
+                organizationId = "organization-id",
+                sessionDurationMinutes = 30
+            )
+            requestIgnoringResponseException {
+                apiService.intermediateSessionExchange(parameters)
+            }.verifyPost(
+                expectedPath = "/b2b/discovery/intermediate_sessions/exchange",
+                expectedBody = mapOf(
+                    "intermediate_session_token" to parameters.intermediateSessionToken,
+                    "organization_id" to parameters.organizationId,
+                    "session_duration_minutes" to parameters.sessionDurationMinutes,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `check Discovery createOrganization request`() {
+        runBlocking {
+            val parameters = B2BRequests.Discovery.CreateRequest(
+                intermediateSessionToken = "intermediate-session-token",
+                organizationName = "organization-name",
+                organizationSlug = "organization-slug",
+                organizationLogoUrl = "organization-logo-url",
+                sessionDurationMinutes = 30
+            )
+            requestIgnoringResponseException {
+                apiService.createOrganization(parameters)
+            }.verifyPost(
+                expectedPath = "/b2b/discovery/organizations/create",
+                expectedBody = mapOf(
+                    "intermediate_session_token" to parameters.intermediateSessionToken,
+                    "organization_name" to parameters.organizationName,
+                    "organization_slug" to parameters.organizationSlug,
+                    "organization_logo_url" to parameters.organizationLogoUrl,
+                    "session_duration_minutes" to parameters.sessionDurationMinutes,
+                )
+            )
+        }
+    }
+    //endregion Discovery
 
     private suspend fun requestIgnoringResponseException(block: suspend () -> Unit): RecordedRequest {
         try {

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -81,6 +81,22 @@ internal class StytchB2BApiTest {
     }
 
     @Test
+    fun `StytchB2BApi MagicLinks Discovery send calls appropriate apiService method`() = runTest {
+        every { StytchB2BApi.isInitialized } returns true
+        coEvery { StytchB2BApi.apiService.sendDiscoveryMagicLink(any()) } returns mockk(relaxed = true)
+        StytchB2BApi.MagicLinks.Discovery.send("", "", "", "")
+        coVerify { StytchB2BApi.apiService.sendDiscoveryMagicLink(any()) }
+    }
+
+    @Test
+    fun `StytchB2BApi MagicLinks Discovery authenticate calls appropriate apiService method`() = runTest {
+        every { StytchB2BApi.isInitialized } returns true
+        coEvery { StytchB2BApi.apiService.authenticateDiscoveryMagicLink(any()) } returns mockk(relaxed = true)
+        StytchB2BApi.MagicLinks.Discovery.authenticate("", "")
+        coVerify { StytchB2BApi.apiService.authenticateDiscoveryMagicLink(any()) }
+    }
+
+    @Test
     fun `StytchB2BApi Sessions authenticate calls appropriate apiService method`() = runTest {
         every { StytchB2BApi.isInitialized } returns true
         coEvery { StytchB2BApi.apiService.authenticateSessions(any()) } returns mockk(relaxed = true)

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -173,6 +173,40 @@ internal class StytchB2BApiTest {
         coVerify { StytchB2BApi.apiService.passwordStrengthCheck(any()) }
     }
 
+    @Test
+    fun `StytchB2BApi Discovery discoverOrganizations calls appropriate apiService method`() = runTest {
+        every { StytchB2BApi.isInitialized } returns true
+        coEvery { StytchB2BApi.apiService.discoverOrganizations(any()) } returns mockk(relaxed = true)
+        StytchB2BApi.Discovery.discoverOrganizations(null)
+        coVerify { StytchB2BApi.apiService.discoverOrganizations(any()) }
+    }
+
+    @Test
+    fun `StytchB2BApi Discovery exchangeSession calls appropriate apiService method`() = runTest {
+        every { StytchB2BApi.isInitialized } returns true
+        coEvery { StytchB2BApi.apiService.intermediateSessionExchange(any()) } returns mockk(relaxed = true)
+        StytchB2BApi.Discovery.exchangeSession(
+            intermediateSessionToken = "",
+            organizationId = "",
+            sessionDurationMinutes = 30U
+        )
+        coVerify { StytchB2BApi.apiService.intermediateSessionExchange(any()) }
+    }
+
+    @Test
+    fun `StytchB2BApi Discovery createOrganization calls appropriate apiService method`() = runTest {
+        every { StytchB2BApi.isInitialized } returns true
+        coEvery { StytchB2BApi.apiService.createOrganization(any()) } returns mockk(relaxed = true)
+        StytchB2BApi.Discovery.createOrganization(
+            intermediateSessionToken = "",
+            organizationLogoUrl = "",
+            organizationSlug = "",
+            organizationName = "",
+            sessionDurationMinutes = 30U
+        )
+        coVerify { StytchB2BApi.apiService.createOrganization(any()) }
+    }
+
     @Test(expected = IllegalStateException::class)
     fun `safeApiCall throws exception when StytchB2BClient is not initialized`() = runTest {
         every { StytchB2BApi.isInitialized } returns false

--- a/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/consumer/StytchClientTest.kt
@@ -3,6 +3,7 @@ package com.stytch.sdk.consumer
 import android.content.Context
 import android.net.Uri
 import com.stytch.sdk.common.DeeplinkHandledStatus
+import com.stytch.sdk.common.DeeplinkResponse
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.StorageHelper
@@ -256,7 +257,7 @@ internal class StytchClientTest {
             coEvery { mockMagicLinks.authenticate(any()) } returns mockAuthResponse
             val response = StytchClient.handle(mockUri, 30U)
             coVerify { mockMagicLinks.authenticate(any()) }
-            assert(response == DeeplinkHandledStatus.Handled(mockAuthResponse))
+            assert(response == DeeplinkHandledStatus.Handled(DeeplinkResponse.Auth(mockAuthResponse)))
         }
     }
 
@@ -271,7 +272,7 @@ internal class StytchClientTest {
             coEvery { mockOAuth.authenticate(any()) } returns mockAuthResponse
             val response = StytchClient.handle(mockUri, 30U)
             coVerify { mockOAuth.authenticate(any()) }
-            assert(response == DeeplinkHandledStatus.Handled(mockAuthResponse))
+            assert(response == DeeplinkHandledStatus.Handled(DeeplinkResponse.Auth(mockAuthResponse)))
         }
     }
 


### PR DESCRIPTION
Linear Ticket: [SDK-962 ](https://linear.app/stytch/issue/SDK-962 )

## Changes:

1. Add discovery endpoints
2. Add/Update tests
3. Add Discovery EML send/authenticate
4. Update workbench

## Notes:

- Discovery magic links authenticate requests do not return a regular authenticated session (no session token, jwt, member, etc) as it only creates an _intermediate_ session. This means that, unfortunately, the DeeplinkHandledStatus class now needs to accept an `Any` instead of `CommonAuthenticationData` 😭 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A