### PR TITLE
Add missing create org params; add params to organization response model

### DIFF
--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/DiscoveryViewModel.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/DiscoveryViewModel.kt
@@ -4,6 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.stytch.sdk.b2b.StytchB2BClient
 import com.stytch.sdk.b2b.discovery.Discovery
+import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
+import com.stytch.sdk.b2b.network.models.AuthMethods
+import com.stytch.sdk.b2b.network.models.EmailInvites
+import com.stytch.sdk.b2b.network.models.EmailJitProvisioning
+import com.stytch.sdk.b2b.network.models.SsoJitProvisioning
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DisposableHandle
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,7 +38,13 @@ class DiscoveryViewModel : ViewModel() {
             _currentResponse.value =
                 StytchB2BClient.discovery.createOrganization(
                     Discovery.CreateOrganizationParameters(
-                        intermediateSessionToken = intermediateSessionToken
+                        intermediateSessionToken = intermediateSessionToken,
+                        ssoJitProvisioning = SsoJitProvisioning.ALL_ALLOWED,
+                        emailJitProvisioning = EmailJitProvisioning.RESTRICTED,
+                        emailInvites = EmailInvites.ALL_ALLOWED,
+                        emailAllowedDomains = listOf("stytch.com"),
+                        authMethods = AuthMethods.ALL_ALLOWED,
+                        allowedAuthMethods = listOf(AllowedAuthMethods.MAGIC_LINK, AllowedAuthMethods.PASSWORD)
                     )
                 ).toFriendlyDisplay()
         }

--- a/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/SSOViewModel.kt
+++ b/b2bExampleApp/src/main/java/com/stytch/exampleapp/b2b/SSOViewModel.kt
@@ -47,7 +47,7 @@ class SSOViewModel : ViewModel() {
                         val result = StytchClient.handle(it, 60U)
                         when (result) {
                             is DeeplinkHandledStatus.NotHandled -> result.reason
-                            is DeeplinkHandledStatus.Handled -> result.response.toFriendlyDisplay()
+                            is DeeplinkHandledStatus.Handled -> result.response.result.toFriendlyDisplay()
                             // This only happens for password reset deeplinks
                             is DeeplinkHandledStatus.ManualHandlingRequired -> ""
                         }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/StytchB2BClient.kt
@@ -236,10 +236,12 @@ public object StytchB2BClient {
                 }
                 B2BTokenType.SSO -> {
                     DeeplinkHandledStatus.Handled(
-                        sso.authenticate(
-                            SSO.AuthenticateParams(
-                                ssoToken = token,
-                                sessionDurationMinutes = sessionDurationMinutes
+                        DeeplinkResponse.Auth(
+                            sso.authenticate(
+                                SSO.AuthenticateParams(
+                                    ssoToken = token,
+                                    sessionDurationMinutes = sessionDurationMinutes
+                                )
                             )
                         )
                     )

--- a/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/discovery/Discovery.kt
@@ -3,6 +3,11 @@ package com.stytch.sdk.b2b.discovery
 import com.stytch.sdk.b2b.DiscoverOrganizationsResponse
 import com.stytch.sdk.b2b.IntermediateSessionExchangeResponse
 import com.stytch.sdk.b2b.OrganizationCreateResponse
+import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
+import com.stytch.sdk.b2b.network.models.AuthMethods
+import com.stytch.sdk.b2b.network.models.EmailInvites
+import com.stytch.sdk.b2b.network.models.EmailJitProvisioning
+import com.stytch.sdk.b2b.network.models.SsoJitProvisioning
 import com.stytch.sdk.common.Constants
 
 /**
@@ -100,6 +105,12 @@ public interface Discovery {
         val organizationSlug: String? = null,
         val organizationLogoUrl: String? = null,
         val sessionDurationMinutes: UInt = Constants.DEFAULT_SESSION_TIME_MINUTES,
+        val ssoJitProvisioning: SsoJitProvisioning? = null,
+        val emailAllowedDomains: List<String>? = null,
+        val emailJitProvisioning: EmailJitProvisioning? = null,
+        val emailInvites: EmailInvites? = null,
+        val authMethods: AuthMethods? = null,
+        val allowedAuthMethods: List<AllowedAuthMethods>? = null,
     )
 
     /**

--- a/sdk/src/main/java/com/stytch/sdk/b2b/discovery/DiscoveryImpl.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/discovery/DiscoveryImpl.kt
@@ -63,7 +63,13 @@ internal class DiscoveryImpl(
                 organizationName = parameters.organizationName,
                 organizationSlug = parameters.organizationSlug,
                 organizationLogoUrl = parameters.organizationLogoUrl,
-                sessionDurationMinutes = parameters.sessionDurationMinutes
+                sessionDurationMinutes = parameters.sessionDurationMinutes,
+                ssoJitProvisioning = parameters.ssoJitProvisioning,
+                emailAllowedDomains = parameters.emailAllowedDomains,
+                emailInvites = parameters.emailInvites,
+                emailJitProvisioning = parameters.emailJitProvisioning,
+                authMethods = parameters.authMethods,
+                allowedAuthMethods = parameters.allowedAuthMethods
             )
         }
     }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/StytchB2BApi.kt
@@ -2,11 +2,15 @@ package com.stytch.sdk.b2b.network
 
 import androidx.annotation.VisibleForTesting
 import com.stytch.sdk.b2b.StytchB2BClient
+import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
+import com.stytch.sdk.b2b.network.models.AuthMethods
 import com.stytch.sdk.b2b.network.models.B2BAuthData
 import com.stytch.sdk.b2b.network.models.B2BEMLAuthenticateData
 import com.stytch.sdk.b2b.network.models.B2BRequests
 import com.stytch.sdk.b2b.network.models.DiscoveredOrganizationsResponseData
 import com.stytch.sdk.b2b.network.models.DiscoveryAuthenticateResponseData
+import com.stytch.sdk.b2b.network.models.EmailInvites
+import com.stytch.sdk.b2b.network.models.EmailJitProvisioning
 import com.stytch.sdk.b2b.network.models.EmailResetResponseData
 import com.stytch.sdk.b2b.network.models.IB2BAuthData
 import com.stytch.sdk.b2b.network.models.IntermediateSessionExchangeResponseData
@@ -16,6 +20,7 @@ import com.stytch.sdk.b2b.network.models.OrganizationResponseData
 import com.stytch.sdk.b2b.network.models.PasswordsAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.SSOAuthenticateResponseData
 import com.stytch.sdk.b2b.network.models.SessionResetResponseData
+import com.stytch.sdk.b2b.network.models.SsoJitProvisioning
 import com.stytch.sdk.b2b.network.models.StrengthCheckResponseData
 import com.stytch.sdk.common.Constants
 import com.stytch.sdk.common.DeviceInfo
@@ -307,12 +312,19 @@ internal object StytchB2BApi {
             )
         }
 
+        @Suppress("LongParameterList")
         suspend fun createOrganization(
             intermediateSessionToken: String,
             sessionDurationMinutes: UInt,
             organizationName: String?,
             organizationSlug: String?,
             organizationLogoUrl: String?,
+            ssoJitProvisioning: SsoJitProvisioning?,
+            emailAllowedDomains: List<String>?,
+            emailJitProvisioning: EmailJitProvisioning?,
+            emailInvites: EmailInvites?,
+            authMethods: AuthMethods?,
+            allowedAuthMethods: List<AllowedAuthMethods>?,
         ): StytchResult<OrganizationCreateResponseData> = safeB2BApiCall {
             apiService.createOrganization(
                 B2BRequests.Discovery.CreateRequest(
@@ -320,7 +332,13 @@ internal object StytchB2BApi {
                     sessionDurationMinutes = sessionDurationMinutes.toInt(),
                     organizationName = organizationName,
                     organizationSlug = organizationSlug,
-                    organizationLogoUrl = organizationLogoUrl
+                    organizationLogoUrl = organizationLogoUrl,
+                    ssoJitProvisioning = ssoJitProvisioning,
+                    emailAllowedDomains = emailAllowedDomains,
+                    emailJitProvisioning = emailJitProvisioning,
+                    emailInvites = emailInvites,
+                    authMethods = authMethods,
+                    allowedAuthMethods = allowedAuthMethods,
                 )
             )
         }

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BRequests.kt
@@ -155,6 +155,18 @@ internal object B2BRequests {
             val organizationSlug: String?,
             @Json(name = "organization_logo_url")
             val organizationLogoUrl: String?,
+            @Json(name = "sso_jit_provisioning")
+            val ssoJitProvisioning: SsoJitProvisioning?,
+            @Json(name = "email_allowed_domains")
+            val emailAllowedDomains: List<String>?,
+            @Json(name = "email_jit_provisioning")
+            val emailJitProvisioning: EmailJitProvisioning?,
+            @Json(name = "email_invites")
+            val emailInvites: EmailInvites?,
+            @Json(name = "auth_methods")
+            val authMethods: AuthMethods?,
+            @Json(name = "allowed_auth_methods")
+            val allowedAuthMethods: List<AllowedAuthMethods>?,
         )
     }
 

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/B2BResponseData.kt
@@ -127,6 +127,32 @@ public data class Organization(
     val organizationLogoUrl: String,
     @Json(name = "trusted_metadata")
     val trustedMetadata: Map<String, Any?>,
+    @Json(name = "sso_default_connection_id")
+    val ssoDefaultConnectionId: String?,
+    @Json(name = "sso_jit_provisioning")
+    val ssoJitProvisioning: SsoJitProvisioning?,
+    @Json(name = "sso_jit_provisioning_allowed_connections")
+    val ssoJitProvisioningAllowedConnections: List<String>?,
+    @Json(name = "sso_active_connections")
+    val ssoActiveConnections: List<SSOActiveConnection>?,
+    @Json(name = "email_allowed_domains")
+    val emailAllowedDomains: List<String>?,
+    @Json(name = "email_jit_provisioning")
+    val emailJitProvisioning: EmailJitProvisioning?,
+    @Json(name = "email_invites")
+    val emailInvites: EmailInvites?,
+    @Json(name = "auth_methods")
+    val authMethods: AuthMethods?,
+    @Json(name = "allowed_auth_methods")
+    val allowedAuthMethods: List<AllowedAuthMethods>?,
+)
+
+@JsonClass(generateAdapter = true)
+public data class SSOActiveConnection(
+    @Json(name = "connection_id")
+    val connectionId: String,
+    @Json(name = "display_name")
+    val displayName: String,
 )
 
 @JsonClass(generateAdapter = true)

--- a/sdk/src/main/java/com/stytch/sdk/b2b/network/models/Enums.kt
+++ b/sdk/src/main/java/com/stytch/sdk/b2b/network/models/Enums.kt
@@ -1,0 +1,31 @@
+package com.stytch.sdk.b2b.network.models
+
+import com.stytch.sdk.common.utils.IEnumValue
+
+public enum class SsoJitProvisioning {
+    ALL_ALLOWED,
+    RESTRICTED,
+    NOT_ALLOWED,
+}
+
+public enum class EmailJitProvisioning {
+    RESTRICTED,
+    NOT_ALLOWED,
+}
+
+public enum class EmailInvites {
+    ALL_ALLOWED,
+    RESTRICTED,
+    NOT_ALLOWED,
+}
+
+public enum class AuthMethods {
+    ALL_ALLOWED,
+    RESTRICTED,
+}
+
+public enum class AllowedAuthMethods(override val jsonName: String) : IEnumValue {
+    SSO("sso"),
+    MAGIC_LINK("magic_link"),
+    PASSWORD("password"),
+}

--- a/sdk/src/main/java/com/stytch/sdk/common/network/ApiService.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/network/ApiService.kt
@@ -1,5 +1,8 @@
 package com.stytch.sdk.common.network
 
+import com.squareup.moshi.Moshi
+import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
+import com.stytch.sdk.common.utils.createEnumJsonAdapter
 import java.util.concurrent.TimeUnit
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -50,9 +53,12 @@ internal interface ApiService {
             revokeSession: () -> Unit,
             apiService: Class<T>
         ): T {
+            val moshi = Moshi.Builder()
+                .add(createEnumJsonAdapter<AllowedAuthMethods>())
+                .build()
             return Retrofit.Builder()
                 .baseUrl(hostUrl)
-                .addConverterFactory(MoshiConverterFactory.create())
+                .addConverterFactory(MoshiConverterFactory.create(moshi))
                 .client(clientBuilder(authHeaderInterceptor, revokeSession))
                 .build()
                 .create(apiService)

--- a/sdk/src/main/java/com/stytch/sdk/common/utils/EnumHelpers.kt
+++ b/sdk/src/main/java/com/stytch/sdk/common/utils/EnumHelpers.kt
@@ -1,0 +1,36 @@
+package com.stytch.sdk.common.utils
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.ToJson
+
+internal interface IEnumValue {
+    val jsonName: String
+}
+
+internal object GenericEnumFactory {
+    inline fun <reified T> fromValueOrNull(rawString: String?): T? where T : Enum<T>, T : IEnumValue {
+        return enumValues<T>().firstOrNull { it.jsonName == rawString }
+    }
+}
+
+internal inline fun <reified T> createEnumJsonAdapter(): JsonAdapter<T> where T : Enum<T>, T : IEnumValue {
+    return object : JsonAdapter<T>() {
+        @FromJson
+        override fun fromJson(reader: JsonReader): T? {
+            return if (reader.peek() != JsonReader.Token.NULL) {
+                val value = reader.nextString()
+                enumValues<T>().firstOrNull { it.jsonName == value }
+            } else {
+                reader.nextNull()
+            }
+        }
+
+        @ToJson
+        override fun toJson(writer: JsonWriter, value: T?) {
+            writer.value(value?.jsonName)
+        }
+    }
+}

--- a/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryImplTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryImplTest.kt
@@ -82,17 +82,19 @@ internal class DiscoveryImplTest {
     @Test
     fun `DiscoveryImpl create delegates to api`() = runTest {
         coEvery {
-            mockApi.createOrganization(any(), any(), any(), any(), any())
+            mockApi.createOrganization(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
         } returns StytchResult.Success(mockk(relaxed = true))
         val response = impl.createOrganization(mockk(relaxed = true))
         assert(response is StytchResult.Success)
-        coVerify { mockApi.createOrganization(any(), any(), any(), any(), any()) }
+        coVerify {
+            mockApi.createOrganization(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
     }
 
     @Test
     fun `DiscoveryImpl create with callback calls callback method`() {
         coEvery {
-            mockApi.createOrganization(any(), any(), any(), any(), any())
+            mockApi.createOrganization(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
         } returns StytchResult.Success(mockk(relaxed = true))
         val mockCallback = spyk<(OrganizationCreateResponse) -> Unit>()
         impl.createOrganization(mockk(relaxed = true), mockCallback)

--- a/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/discovery/DiscoveryTest.kt
@@ -36,6 +36,12 @@ internal class DiscoveryTest {
             organizationSlug = null,
             organizationLogoUrl = null,
             sessionDurationMinutes = Constants.DEFAULT_SESSION_TIME_MINUTES,
+            ssoJitProvisioning = null,
+            emailAllowedDomains = null,
+            emailJitProvisioning = null,
+            emailInvites = null,
+            authMethods = null,
+            allowedAuthMethods = null,
         )
         assert(params == expected)
     }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiServiceTest.kt
@@ -1,6 +1,11 @@
 package com.stytch.sdk.b2b.network
 
+import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
+import com.stytch.sdk.b2b.network.models.AuthMethods
 import com.stytch.sdk.b2b.network.models.B2BRequests
+import com.stytch.sdk.b2b.network.models.EmailInvites
+import com.stytch.sdk.b2b.network.models.EmailJitProvisioning
+import com.stytch.sdk.b2b.network.models.SsoJitProvisioning
 import com.stytch.sdk.common.network.ApiService
 import com.stytch.sdk.common.network.models.CommonRequests
 import com.stytch.sdk.utils.verifyGet
@@ -372,7 +377,16 @@ internal class StytchB2BApiServiceTest {
                 organizationName = "organization-name",
                 organizationSlug = "organization-slug",
                 organizationLogoUrl = "organization-logo-url",
-                sessionDurationMinutes = 30
+                sessionDurationMinutes = 30,
+                ssoJitProvisioning = SsoJitProvisioning.ALL_ALLOWED,
+                emailAllowedDomains = listOf("alloweddomain.com"),
+                emailInvites = EmailInvites.NOT_ALLOWED,
+                emailJitProvisioning = EmailJitProvisioning.RESTRICTED,
+                authMethods = AuthMethods.RESTRICTED,
+                allowedAuthMethods = listOf(
+                    AllowedAuthMethods.MAGIC_LINK,
+                    AllowedAuthMethods.PASSWORD
+                )
             )
             requestIgnoringResponseException {
                 apiService.createOrganization(parameters)
@@ -384,6 +398,12 @@ internal class StytchB2BApiServiceTest {
                     "organization_slug" to parameters.organizationSlug,
                     "organization_logo_url" to parameters.organizationLogoUrl,
                     "session_duration_minutes" to parameters.sessionDurationMinutes,
+                    "sso_jit_provisioning" to parameters.ssoJitProvisioning,
+                    "email_allowed_domains" to parameters.emailAllowedDomains,
+                    "email_jit_provisioning" to parameters.emailJitProvisioning,
+                    "email_invites" to parameters.emailInvites,
+                    "auth_methods" to parameters.authMethods,
+                    "allowed_auth_methods" to parameters.allowedAuthMethods?.map { it.jsonName },
                 )
             )
         }

--- a/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
+++ b/sdk/src/test/java/com/stytch/sdk/b2b/network/StytchB2BApiTest.kt
@@ -2,6 +2,12 @@ package com.stytch.sdk.b2b.network
 
 import android.content.Context
 import com.stytch.sdk.b2b.StytchB2BClient
+import com.stytch.sdk.b2b.network.models.AllowedAuthMethods
+import com.stytch.sdk.b2b.network.models.AuthMethods
+import com.stytch.sdk.b2b.network.models.B2BRequests
+import com.stytch.sdk.b2b.network.models.EmailInvites
+import com.stytch.sdk.b2b.network.models.EmailJitProvisioning
+import com.stytch.sdk.b2b.network.models.SsoJitProvisioning
 import com.stytch.sdk.common.DeviceInfo
 import com.stytch.sdk.common.EncryptionManager
 import com.stytch.sdk.common.StorageHelper
@@ -218,9 +224,28 @@ internal class StytchB2BApiTest {
             organizationLogoUrl = "",
             organizationSlug = "",
             organizationName = "",
-            sessionDurationMinutes = 30U
+            sessionDurationMinutes = 30U,
+            ssoJitProvisioning = SsoJitProvisioning.ALL_ALLOWED,
+            emailJitProvisioning = EmailJitProvisioning.RESTRICTED,
+            emailInvites = EmailInvites.ALL_ALLOWED,
+            emailAllowedDomains = listOf("allowed-domain.com"),
+            authMethods = AuthMethods.RESTRICTED,
+            allowedAuthMethods = listOf(AllowedAuthMethods.PASSWORD, AllowedAuthMethods.MAGIC_LINK),
         )
-        coVerify { StytchB2BApi.apiService.createOrganization(any()) }
+        val expectedParams = B2BRequests.Discovery.CreateRequest(
+            intermediateSessionToken = "",
+            organizationLogoUrl = "",
+            organizationSlug = "",
+            organizationName = "",
+            sessionDurationMinutes = 30,
+            ssoJitProvisioning = SsoJitProvisioning.ALL_ALLOWED,
+            emailJitProvisioning = EmailJitProvisioning.RESTRICTED,
+            emailInvites = EmailInvites.ALL_ALLOWED,
+            emailAllowedDomains = listOf("allowed-domain.com"),
+            authMethods = AuthMethods.RESTRICTED,
+            allowedAuthMethods = listOf(AllowedAuthMethods.PASSWORD, AllowedAuthMethods.MAGIC_LINK),
+        )
+        coVerify { StytchB2BApi.apiService.createOrganization(expectedParams) }
     }
 
     @Test

--- a/sdk/src/test/java/com/stytch/sdk/utils/RecordedRequestExtensions.kt
+++ b/sdk/src/test/java/com/stytch/sdk/utils/RecordedRequestExtensions.kt
@@ -1,5 +1,6 @@
 package com.stytch.sdk.utils
 
+import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonParser
 import okhttp3.mockwebserver.RecordedRequest
@@ -22,8 +23,24 @@ private fun compare(key: String, requestValue: JsonElement, expectedValue: Any?)
             val nestedRequestValue = nestedObject.get(nestedKey)
             compare(nestedKey, nestedRequestValue, expectedValue[nestedKey])
         }
+    } else if (requestValue.isJsonArray) {
+        val array = requestValue.asJsonArray
+        require(expectedValue is List<*>) {
+            "Request contains a list, but expected was not a list"
+        }
+        require(array.size() == expectedValue.size) {
+            "Request contains ${array.size()} elements but expected ${expectedValue.size}"
+        }
+        val expectedAsJsonArray = JsonArray(expectedValue.size).apply {
+            expectedValue.forEach {
+                add(it.toString())
+            }
+        }
+        require(requestValue == expectedAsJsonArray) {
+            "Expected $expectedValue but got $requestValue"
+        }
     } else {
-        // primitives and arrays can be string compared
+        // primitives can be string compared
         require(requestValue.asString == expectedValue.toString()) {
             "Expected $expectedValue but got $requestValue"
         }


### PR DESCRIPTION
Linear Ticket: No Ticket

## Changes:

1. Add missing createOrganization params
2. Add them to the organization response model, too
3. Update tests

## Notes:

- 

## Checklist:
- [x] I have verified that this change works in the relevant demo app, or N/A
- [x] I have added or updated any tests relevant to this change, or N/A
- [x] I have updated any relevant README files for this change, or N/A